### PR TITLE
Adding Procfile for heroku deployment

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: bundle exec puma -C config/puma.rb


### PR DESCRIPTION
Adding the Heroku Procfile based on the findings from this article: https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server. We may have to make some changes based on what we find when we meet to discuss Heroku deployment but this should give us a good start. I choose to run the server from the puma configuration file since it will either look for an environment variable for the rack environment or it will default to development. So, we can easily change the environment of the app for staging and production.