### PR TITLE
Improved handling of header tags for jekyll

### DIFF
--- a/app/services/kramdown_service.rb
+++ b/app/services/kramdown_service.rb
@@ -22,9 +22,10 @@ module KramdownService
     # +author+:: the author of the post
     # +title+:: the title of the post
     # +tags+:: tags specific to the post
-    # +overlay+:: the overlay cikir of the post
+    # +overlay+:: the overlay color of the post
     def create_jekyll_post_text(text, author, title, tags, overlay)
-      # https://source.unsplash.com/collection/145103/
+      header_converted_text = fix_header_syntax(text)
+
       parsed_tags = parse_tags(tags)
 
       tag_section = %(tags:
@@ -58,6 +59,18 @@ published: true
           result << "\r\n" if tag != tag_array.last
         end
         result
+      end
+
+      def fix_header_syntax(text)
+        document = Kramdown::Document.new(text)
+        header_elements = document.root.children.select { |x| x.type == :header}
+        lines = text.split("\n")
+        lines = lines.map do |line|
+          if header_elements.any? { |x| line.include? x.options[:raw_text] }
+            line_match = line.match(/(.)\1+(.*)/)
+            puts line_match.captures
+          end
+        end
       end
   end
 end

--- a/app/services/kramdown_service.rb
+++ b/app/services/kramdown_service.rb
@@ -62,7 +62,7 @@ published: true
 
       def fix_header_syntax(text)
         document = Kramdown::Document.new(text)
-        header_elements = document.root.children.select { |x| x.type == :header}
+        header_elements = document.root.children.select { |x| x.type == :header }
         lines = text.split("\n")
         lines = lines.map do |line|
           if header_elements.any? { |x| line.include? x.options[:raw_text] }

--- a/app/services/kramdown_service.rb
+++ b/app/services/kramdown_service.rb
@@ -25,7 +25,6 @@ module KramdownService
     # +overlay+:: the overlay color of the post
     def create_jekyll_post_text(text, author, title, tags, overlay)
       header_converted_text = fix_header_syntax(text)
-
       parsed_tags = parse_tags(tags)
 
       tag_section = %(tags:
@@ -44,7 +43,7 @@ overlay: #{overlay.downcase}
 published: true
 ---
 #{lead_break_section}
-#{text})
+#{header_converted_text})
 
       result
     end
@@ -67,10 +66,15 @@ published: true
         lines = text.split("\n")
         lines = lines.map do |line|
           if header_elements.any? { |x| line.include? x.options[:raw_text] }
-            line_match = line.match(/(.)\1+(.*)/)
-            puts line_match.captures
+            # This regex matches the line into 2 groups with the first group being the repeating #
+            # characters and the beginning of the string and the second group being the rest of the string
+            line_match = line.match(/(#)\1*(.*)/)
+            line = "#{line_match.captures.first} #{line_match.captures.last}"
+          else
+            line
           end
         end
+        lines.join("\n")
       end
   end
 end

--- a/app/services/kramdown_service.rb
+++ b/app/services/kramdown_service.rb
@@ -68,7 +68,7 @@ published: true
           if header_elements.any? { |x| line.include? x.options[:raw_text] }
             # This regex matches the line into 2 groups with the first group being the repeating #
             # characters and the beginning of the string and the second group being the rest of the string
-            line_match = line.match(/(#)\1*(.*)/)
+            line_match = line.match(/(#*)(.*)/)
             line = "#{line_match.captures.first} #{line_match.captures.last}"
           else
             line

--- a/test/services/kramdown_service_test.rb
+++ b/test/services/kramdown_service_test.rb
@@ -60,36 +60,36 @@ published: true
     assert_equal expected_post, result
   end
 
-#   test 'create_jekyll_post_text should add a space after the # symbols indicating a header tag' do 
-#     # Arrange
-#     expected_post = %(---
-# layout: post
-# title: Some Post
-# author: Andy Wojciechowski\r
-# hero: https://source.unsplash.com/collection/145103/
-# overlay: green
-# published: true
-# ---
-# #{LEAD_BREAK_SECTION}
-# # H1 header\r
-# \r
-# ## H2 header\r
-# \r
-# ### H3 header\r
-# \r
-# #### H4 header\r
-# \r
-# ##### H5 header\r
-# \r
-# ###### H6 header)
+  test 'create_jekyll_post_text should add a space after the # symbols indicating a header tag' do 
+    # Arrange
+    expected_post = %(---
+layout: post
+title: Some Post
+author: Andy Wojciechowski\r
+hero: https://source.unsplash.com/collection/145103/
+overlay: green
+published: true
+---
+#{LEAD_BREAK_SECTION}
+# H1 header\r
+\r
+## H2 header\r
+\r
+### H3 header\r
+\r
+#### H4 header\r
+\r
+##### H5 header\r
+\r
+###### H6 header)
 
-#     markdown_text = "#H1 header\r\n\r\n##H2 header\r\n\r\n##H3 header\r\n\r\n####H4 header\r\n\r\n
-#                      #####H5 header\r\n\r\n######H6 header"
+    markdown_text = "#H1 header\r\n\r\n##H2 header\r\n\r\n##H3 header\r\n\r\n####H4 header\r\n\r\n
+                     #####H5 header\r\n\r\n######H6 header"
 
-#     # Act
-#     result = KramdownService.create_jekyll_post_text(markdown_text, 'Andy Wojciechowski', 'Some Post', '', 'Green')
+    # Act
+    result = KramdownService.create_jekyll_post_text(markdown_text, 'Andy Wojciechowski', 'Some Post', '', 'Green')
 
-#     # Assert
-#     assert_equal expected_post, result
-#   end
+    # Assert
+    assert_equal expected_post, result
+  end
 end

--- a/test/services/kramdown_service_test.rb
+++ b/test/services/kramdown_service_test.rb
@@ -26,7 +26,7 @@ overlay: green
 published: true
 ---
 #{LEAD_BREAK_SECTION}
-#An H1 tag\r
+# An H1 tag\r
 ##An H2 tag)
 
     # Act
@@ -51,7 +51,7 @@ overlay: green
 published: true
 ---
 #{LEAD_BREAK_SECTION}
-#An H1 tag\r
+# An H1 tag\r
 ##An H2 tag)
     # Act
     result = KramdownService.create_jekyll_post_text("#An H1 tag\r\n##An H2 tag",
@@ -59,4 +59,37 @@ published: true
     # Assert
     assert_equal expected_post, result
   end
+
+#   test 'create_jekyll_post_text should add a space after the # symbols indicating a header tag' do 
+#     # Arrange
+#     expected_post = %(---
+# layout: post
+# title: Some Post
+# author: Andy Wojciechowski\r
+# hero: https://source.unsplash.com/collection/145103/
+# overlay: green
+# published: true
+# ---
+# #{LEAD_BREAK_SECTION}
+# # H1 header\r
+# \r
+# ## H2 header\r
+# \r
+# ### H3 header\r
+# \r
+# #### H4 header\r
+# \r
+# ##### H5 header\r
+# \r
+# ###### H6 header)
+
+#     markdown_text = "#H1 header\r\n\r\n##H2 header\r\n\r\n##H3 header\r\n\r\n####H4 header\r\n\r\n
+#                      #####H5 header\r\n\r\n######H6 header"
+
+#     # Act
+#     result = KramdownService.create_jekyll_post_text(markdown_text, 'Andy Wojciechowski', 'Some Post', '', 'Green')
+
+#     # Assert
+#     assert_equal expected_post, result
+#   end
 end

--- a/test/services/kramdown_service_test.rb
+++ b/test/services/kramdown_service_test.rb
@@ -83,8 +83,17 @@ published: true
 \r
 ###### H6 header)
 
-    markdown_text = "#H1 header\r\n\r\n##H2 header\r\n\r\n##H3 header\r\n\r\n####H4 header\r\n\r\n
-                     #####H5 header\r\n\r\n######H6 header"
+    markdown_text = %(#H1 header\r
+\r
+##H2 header\r
+\r
+###H3 header\r
+\r
+####H4 header\r
+\r
+#####H5 header\r
+\r
+######H6 header)
 
     # Act
     result = KramdownService.create_jekyll_post_text(markdown_text, 'Andy Wojciechowski', 'Some Post', '', 'Green')


### PR DESCRIPTION
This PR handles a weird difference between just straight kramdown and kramdown for a jekyll website. For example if I were to type a post like below into the editor.
```markdown
#H1 header

##H2 header

###H3 header

####H4 header

#####H5 header

######H6 header
```
All of those headers will be rendered as header tags in the preview but they will be rendered as paragraph tags in jekyll. To get around this I added handling to add 1 space after the # symbols and turn the markdown above into the markdown below.
```markdown
# H1 header

## H2 header

### H3 header

#### H4 header

##### H5 header

###### H6 header
```