### PR TITLE
Added a confirmation message when a post is successfully submited

### DIFF
--- a/app/assets/javascripts/post.js
+++ b/app/assets/javascripts/post.js
@@ -1,4 +1,6 @@
 $(function() {
+  $('.notice').fadeOut(5000);
+
   $('#preview-button').click(function() {
     setActiveTab("#preview-button", '#PreviewTabContent');
     let url = new URL(`${window.location.origin}/post/preview`);

--- a/app/assets/stylesheets/post.scss
+++ b/app/assets/stylesheets/post.scss
@@ -92,3 +92,8 @@ label {
   justify-content: center;
   color: red;
 }
+
+.notice {
+  display: flex;
+  justify-content: center;
+}

--- a/app/controllers/post_controller.rb
+++ b/app/controllers/post_controller.rb
@@ -32,6 +32,7 @@ class PostController < BasePostEditorController
       full_post_text = KramdownService.create_jekyll_post_text(params[:markdownArea], params[:author], 
                                                                params[:title], params[:tags], params[:overlay])
       GithubService.submit_post(session[:access_token], full_post_text, params[:title])
+      flash[:notice] = 'Post Successfully Submited'
       redirect_to action: 'edit'
     end
   end

--- a/app/views/post/edit.html.erb
+++ b/app/views/post/edit.html.erb
@@ -1,6 +1,9 @@
 <%= form_tag('/post/submit', method: 'post') do %>
-  <% flash.each do |name, msg| %>
-    <%= content_tag :div, msg, class: 'validation-message' %>
+  <% if flash[:alert] %>
+    <%= content_tag :div, flash[:alert], class: 'validation-message' %>
+  <% end %>
+  <% if flash[:notice] %>
+    <%= content_tag :div, flash[:notice], class: 'notice' %>
   <% end %>
   <%= content_tag(:div, id: 'container') do %>
     <%= content_tag(:div, id: 'middle-container') do %>

--- a/test/integration/post_controller_test.rb
+++ b/test/integration/post_controller_test.rb
@@ -118,6 +118,7 @@ class PostControllerTest < ActionDispatch::IntegrationTest
     # Assert
     assert_redirected_to '/'
     assert_equal 'A post cannot be submited with a blank title.', flash[:alert]
+    assert_nil flash[:notice]
   end
 
   test 'post/submit should redirect back to the edit screen 
@@ -136,6 +137,7 @@ class PostControllerTest < ActionDispatch::IntegrationTest
     # Assert
     assert_redirected_to '/'
     assert_equal 'A post cannot be submited without an author.', flash[:alert]
+    assert_nil flash[:notice]
   end
 
   test 'post/submit should redirect back to the edit screen 
@@ -154,6 +156,7 @@ class PostControllerTest < ActionDispatch::IntegrationTest
     # Assert
     assert_redirected_to '/'
     assert_equal 'A post cannot be submited with no markdown content.', flash[:alert]
+    assert_nil flash[:notice]
   end
 
   test 'post/submit should submit the post to GitHub and redirect back to the edit screen with a valid post' do 
@@ -171,6 +174,8 @@ class PostControllerTest < ActionDispatch::IntegrationTest
             
     # Assert
     assert_redirected_to '/post/edit'
+    assert_nil flash[:alert]
+    assert_equal 'Post Successfully Submited', flash[:notice]
   end
 
   private


### PR DESCRIPTION
I thought it would improve the user experience if we had a confirmation message appear if a post was successfully submitted so I did what I did previously with validation messages and used rails flash messages to display that a user's post was successfully submitted once we redirect back to the edit view.