### PR TITLE
Added a file size limit to uploaded images

### DIFF
--- a/app/assets/javascripts/postEdit.js
+++ b/app/assets/javascripts/postEdit.js
@@ -22,6 +22,7 @@ $(function() {
   $('#MarkdownTabContent').dropzone({
     url: '/image/upload',
     acceptedFiles: 'image/jpeg, image/jpg, image/png, image/gif',
+    maxFilesize: 5,
     success: function(file, response) {
       let markdownTextArea = $('#markdownArea');
 

--- a/app/uploaders/post_image_uploader.rb
+++ b/app/uploaders/post_image_uploader.rb
@@ -17,6 +17,13 @@ class PostImageUploader < CarrierWave::Uploader::Base
     ['jpg', 'jpeg', 'gif', 'png']
   end
 
+  def size_range
+    # 5 mb is a very large photo it will probably never be reached. But
+    # this will prevent people from passing off very large files as an image.
+    # If you change this limit please document the reason for changing it below
+    1..5.megabytes
+  end
+
   version :preview do 
     process resize_to_limit: PREVIEW_LIMIT
   end

--- a/test/uploaders/post_image_uploader_test.rb
+++ b/test/uploaders/post_image_uploader_test.rb
@@ -11,4 +11,15 @@ class PostImageUploaderTest < ActiveSupport::TestCase
     # Assert
     assert_equal ['jpg', 'jpeg', 'gif', 'png'], result
   end
+
+  test 'PostImageUploader should limit files to an appropriate size' do 
+    # Arrange
+    uploader = PostImageUploader.new
+
+    # Act
+    result = uploader.size_range
+
+    # Assert
+    assert_equal 1..5.megabytes, result
+  end
 end


### PR DESCRIPTION
This adds a limit of uploaded images to 5mb. 5mb is a very large picture and I don't think anyone will exceed that limit but this should protect against people trying to upload a file with an image extension with GB of data on the file.