### PR TITLE
Fixed spaces being stripped from tag names.

### DIFF
--- a/app/services/kramdown_service.rb
+++ b/app/services/kramdown_service.rb
@@ -85,11 +85,10 @@ published: true
 
     private
       def parse_tags(tags)
-        tags_no_whitepsace = tags.gsub(/\s+/, '')
-        tag_array = tags_no_whitepsace.split(',')
+        tag_array = tags.split(',')
         result = ''
         tag_array.each do |tag|
-          result << "  - #{tag}"
+          result << "  - #{tag.strip}"
           result << "\r\n" if tag != tag_array.last
         end
         result

--- a/test/services/kramdown_service_test.rb
+++ b/test/services/kramdown_service_test.rb
@@ -103,6 +103,7 @@ author: Andy Wojciechowski\r
 tags:
   - announcement\r
   - info\r
+  - hack n tell\r
 hero: https://source.unsplash.com/collection/145103/
 overlay: green
 published: true
@@ -112,7 +113,10 @@ published: true
 ##An H2 tag)
     # Act
     result = KramdownService.create_jekyll_post_text("#An H1 tag\r\n##An H2 tag",
-                                                     'Andy Wojciechowski', 'Some Post', 'announcement, info', 'green')
+                                                     'Andy Wojciechowski', 
+                                                     'Some Post', 
+                                                     'announcement, info,    hack n tell     ', 
+                                                     'green')
     # Assert
     assert_equal expected_post, result
   end


### PR DESCRIPTION
This is a fix for issue #24. Where before a tag entered as hack n tell would appear as hackntell on the website. Now the tag should appear as hack n tell on the website.

This was fixed by not stripping all whitespace from the comma separated string of tags that a user enters and I only strip leading and trailing whitespace from each individual tag.