### PR TITLE
Added handling for image filenames uploaded with spaces

### DIFF
--- a/app/services/kramdown_service.rb
+++ b/app/services/kramdown_service.rb
@@ -36,17 +36,21 @@ module KramdownService
     end
 
     ##
-    # This method returns if an image tag exists with a given filename in some markdown text
+    # This method returns the image filename given some markdown
     #
     # Params:
     # +image_file_name+:: a filename of a image to look for in markdown
     # +markdown+:: text of a markdown post
-    def does_markdown_include_image(image_file_name, markdown)
+    def get_image_filename_from_markdown(image_file_name, markdown)
       document = Kramdown::Document.new(markdown)
       document_descendants = []
+
       get_document_descendants(document.root, document_descendants)
       all_img_tags = document_descendants.select { |x| x.type == :img }
-      all_img_tags.any? { |x| File.basename(x.attr['src']).tr(' ', '_') == image_file_name }
+      matching_image_tag = all_img_tags.find { |x| get_filename_for_image_tag(x).tr(' ', '_') == image_file_name }
+      
+      return get_filename_for_image_tag(matching_image_tag) if matching_image_tag
+      nil
     end
 
     ##
@@ -118,6 +122,10 @@ published: true
           result << element
           get_document_descendants(element, result)
         end
+      end
+
+      def get_filename_for_image_tag(image_el)
+        File.basename(image_el.attr['src'])
       end
   end
 end

--- a/app/services/kramdown_service.rb
+++ b/app/services/kramdown_service.rb
@@ -46,7 +46,7 @@ module KramdownService
       document_descendants = []
       get_document_descendants(document.root, document_descendants)
       all_img_tags = document_descendants.select { |x| x.type == :img }
-      all_img_tags.any? { |x| File.basename(x.attr['src']) == image_file_name }
+      all_img_tags.any? { |x| File.basename(x.attr['src']).tr(' ', '_') == image_file_name }
     end
 
     ##

--- a/app/services/kramdown_service.rb
+++ b/app/services/kramdown_service.rb
@@ -14,7 +14,8 @@ module Kramdown::Converter
     # +el+::the image element to convert to html
     # +_indent+::the indent of the HTML
     def convert_img(el, _indent)
-      uploader = PostImageManager.instance.uploaders.find { |x| x.filename == File.basename(el.attr['src']) }
+      formatted_filename = File.basename(el.attr['src']).tr(' ', '_') 
+      uploader = PostImageManager.instance.uploaders.find { |x| x.filename == formatted_filename }
       el.attr['src'] = "/uploads/tmp/#{uploader.preview.cache_name}" if uploader
       super(el, _indent)
     end

--- a/app/services/post_service.rb
+++ b/app/services/post_service.rb
@@ -52,11 +52,12 @@ module PostService
       def create_image_blobs(oauth_token, post_markdown, current_file_information)
         PostImageManager.instance.uploaders.each do |uploader|
           # This check prevents against images that have been removed from the markdown
-          if KramdownService.does_markdown_include_image(uploader.filename, post_markdown)
+          markdown_file_name = KramdownService.get_image_filename_from_markdown(uploader.filename, post_markdown)
+          if markdown_file_name
             # This line uses .file.file since the first .file returns a carrierware object
             base_64_encoded_image = Base64.encode64(File.open(uploader.post_image.file.file, 'rb').read)
             image_blob_sha = GithubService.create_base64_encoded_blob(oauth_token, base_64_encoded_image)
-            current_file_information << { path: "assets/img/#{uploader.filename}", blob_sha: image_blob_sha }
+            current_file_information << { path: "assets/img/#{markdown_file_name}", blob_sha: image_blob_sha }
           end
         end
       end

--- a/test/services/kramdown_service_test.rb
+++ b/test/services/kramdown_service_test.rb
@@ -91,6 +91,19 @@ Andy is nice)
     assert result
   end
 
+  # Test Case for Issue 22 on GitHub
+  test 'does_markdown_include_image should return true if the markdown does include an image with a given filename 
+        and the filename has been formatted by CarrierWave' do 
+    # Arrange
+    markdown = '![My Alt Text](/assets/img/My File.jpg)'
+
+    # Act
+    result = KramdownService.does_markdown_include_image('My_File.jpg', markdown)
+
+    # Assert
+    assert result
+  end
+
   test 'create_jekyll_post_text should return text for a formatted post' do 
     # Arrange
     expected_post = %(---

--- a/test/services/kramdown_service_test.rb
+++ b/test/services/kramdown_service_test.rb
@@ -49,6 +49,25 @@ Andy is nice)
     assert_equal expected_html, result
   end
 
+  # Test Case for Issue 22 on GitHub
+  test 'get_preview should update the src attribute of images tags if an uploader 
+        with a formatted filename exists in PostImageManager' do 
+    # Arrange
+    mock_uploader = create_mock_uploader('preview_My_File.jpg', 'my cache/preview_My_File.jpg', nil)
+    preview_uploader = create_preview_uploader('My_File.jpg', mock_uploader)
+
+    PostImageManager.instance.expects(:uploaders).returns([ preview_uploader ])
+
+    markdown = '![My Alt Text](/assets/img/My File.jpg)'
+    expected_html = "<p><img src=\"/uploads/tmp/my cache/preview_My_File.jpg\" alt=\"My Alt Text\" /></p>\n"
+
+    # Act
+    result = KramdownService.get_preview(markdown)
+
+    # Assert
+    assert_equal expected_html, result
+  end
+
   test 'does_markdown_include_image should return false if the markdown doesnt 
         include an image with a given filename' do 
     # Arrange

--- a/test/services/kramdown_service_test.rb
+++ b/test/services/kramdown_service_test.rb
@@ -68,40 +68,41 @@ Andy is nice)
     assert_equal expected_html, result
   end
 
-  test 'does_markdown_include_image should return false if the markdown doesnt 
+  test 'get_image_filename_from_markdown should return nil if the markdown doesnt 
         include an image with a given filename' do 
     # Arrange
     markdown = '![My Alt Text](/assets/img/20170610130401_1.jpg)'
 
     # Act
-    result = KramdownService.does_markdown_include_image('my file.jpg', markdown)
+    result = KramdownService.get_image_filename_from_markdown('my file.jpg', markdown)
 
     # Assert
     assert_not result
   end
 
-  test 'does_markdown_include_image should return true if the markdown does include an image with a given filename' do 
+  test 'get_image_filename_from_markdown should return a filename if the markdown does 
+        include an image with a given filename' do 
     # Arrange
     markdown = '![My Alt Text](/assets/img/20170610130401_1.jpg)'
 
     # Act
-    result = KramdownService.does_markdown_include_image('20170610130401_1.jpg', markdown)
+    result = KramdownService.get_image_filename_from_markdown('20170610130401_1.jpg', markdown)
 
     # Assert
-    assert result
+    assert_equal '20170610130401_1.jpg', result
   end
 
   # Test Case for Issue 22 on GitHub
-  test 'does_markdown_include_image should return true if the markdown does include an image with a given filename 
+  test 'get_image_filename_from_markdown should return true if the markdown does include an image with a given filename 
         and the filename has been formatted by CarrierWave' do 
     # Arrange
     markdown = '![My Alt Text](/assets/img/My File.jpg)'
 
     # Act
-    result = KramdownService.does_markdown_include_image('My_File.jpg', markdown)
+    result = KramdownService.get_image_filename_from_markdown('My_File.jpg', markdown)
 
     # Assert
-    assert result
+    assert_equal 'My File.jpg', result
   end
 
   test 'create_jekyll_post_text should return text for a formatted post' do 

--- a/test/services/post_service_test.rb
+++ b/test/services/post_service_test.rb
@@ -67,20 +67,20 @@ class PostServiceTest < ActiveSupport::TestCase
   test 'submit_post should upload any images if any exist in the PostImageManager' do 
     # Arrange
     post_file_path = "_posts/#{DateTime.now.strftime('%Y-%m-%d')}-TestPost.md"
-    test_markdown = "# hello\r\n![My File.jpg](/assets/img/My File.jpg)"
+    test_markdown = "# hello\r\n![My File.jpg](/assets/img/My Image 1.jpg)"
 
-    mock_uploader1 = create_mock_uploader('post_image-My Image 1.jpg', 'cache 1', 
+    mock_uploader1 = create_mock_uploader('post_image-My_Image_1.jpg', 'cache 1', 
                                            create_mock_carrierware_file('C:\post_image-My Image 1.jpg'))
-    post_image_uploader1 = create_post_image_uploader('My Image 1.jpg', mock_uploader1)
+    post_image_uploader1 = create_post_image_uploader('My_Image_1.jpg', mock_uploader1)
 
-    mock_uploader2 = create_mock_uploader('post_image-My Image 2.jpg', 'cache 2', 
+    mock_uploader2 = create_mock_uploader('post_image-My_Image_2.jpg', 'cache 2', 
                                            create_mock_carrierware_file('C:\post_image-My Image 2.jpg'))
-    post_image_uploader2 = create_post_image_uploader('My Image 2.jpg', mock_uploader2)
+    post_image_uploader2 = create_post_image_uploader('My_Image_2.jpg', mock_uploader2)
     
-    KramdownService.expects(:does_markdown_include_image)
-                   .with('My Image 1.jpg', test_markdown).returns(true)
-    KramdownService.expects(:does_markdown_include_image)
-                   .with('My Image 2.jpg', test_markdown).returns(false)
+    KramdownService.expects(:get_image_filename_from_markdown)
+                   .with('My_Image_1.jpg', test_markdown).returns('My Image 1.jpg')
+    KramdownService.expects(:get_image_filename_from_markdown)
+                   .with('My_Image_2.jpg', test_markdown).returns(nil)
     
     image_blob_sha1 = mock_image_blob_and_return_sha(post_image_uploader1)
     PostImageManager.instance.expects(:uploaders).returns([ post_image_uploader1, post_image_uploader2 ])


### PR DESCRIPTION
This is a fix for the very annoying issue #22. This bug was discovered after a few of the hack n tell images had spaces in them and 1/3 were only being uploaded to the site.

Before what CarrierWave would do is if a image like My File.jpg was uploaded the image was appear as My_File.jpg in the cache which previously had no handling before and the image wouldn't get uploaded to the site.

With this fix I added handling to the preview to look for a filename with spaces replaced with _ characters and on GitHub the image is uploaded with the spaces in it which should match the markdown generated by the drag and drop.