### PR TITLE
Full intial implementation of editing

### DIFF
--- a/app/controllers/post_controller.rb
+++ b/app/controllers/post_controller.rb
@@ -30,7 +30,11 @@ class PostController < BasePostEditorController
     else
       full_post_text = KramdownService.create_jekyll_post_text(params[:markdownArea], params[:author], 
                                                                params[:title], params[:tags], params[:overlay])
-      PostService.submit_post(session[:access_token], full_post_text, params[:title])
+      if params[:path]
+        PostService.edit_post(session[:access_token], full_post_text, params[:title], params[:path])
+      else
+        PostService.create_post(session[:access_token], full_post_text, params[:title])
+      end
       flash[:notice] = 'Post Successfully Submited'
       redirect_to action: 'edit'
     end

--- a/app/factories/post_factory.rb
+++ b/app/factories/post_factory.rb
@@ -3,6 +3,9 @@ require_relative '../models/post'
 ##
 # This module is a factory for parsing post text and creating a correseponding post model
 module PostFactory
+  LEAD = '{: .lead}'
+  BREAK = '<!–-break-–>'
+
   class << self
     ##
     # This method parses markdown in a post a returns a post model
@@ -34,6 +37,10 @@ module PostFactory
       
       parse_post_header(header, result)
       result.contents = match_obj.captures[2]
+                                 .remove("#{LEAD}\r\n")
+                                 .remove("#{LEAD}\n")
+                                 .remove("#{BREAK}\r\n")
+                                 .remove("#{BREAK}\n")
       result.tags = parse_tags(header)
       result
     end

--- a/app/factories/post_factory.rb
+++ b/app/factories/post_factory.rb
@@ -29,11 +29,11 @@ module PostFactory
       # What this regular expression does is it matches two groups
       # The first group represents the header of the post which appears
       # between the two --- lines. The second group represents the actual post contents
-      match_obj = post_contents.match(/---(.*)---\n(.*)/m)
+      match_obj = post_contents.match(/---(.*)---(\r\n|\r|\n)(.*)/m)
       header = match_obj.captures[0]
       
       parse_post_header(header, result)
-      result.contents = match_obj.captures[1]
+      result.contents = match_obj.captures[2]
       result.tags = parse_tags(header)
       result
     end
@@ -41,10 +41,10 @@ module PostFactory
     def parse_post_header(header, post_model)
       # The following regular expressions in this method look for specific properities
       # located in the post header.
-      post_model.title = header.match(/title:\s*(.*)\n/).captures.first
-      post_model.author = header.match(/author:\s*(.*)\n/).captures.first
-      post_model.hero = header.match(/hero:\s*(.*)\n/).captures.first
-      post_model.overlay = header.match(/overlay:\s*(.*)\n/).captures.first
+      post_model.title = header.match(/title:\s*(.*)(\r\n|\r|\n)/).captures.first
+      post_model.author = header.match(/author:\s*(.*)(\r\n|\r|\n)/).captures.first
+      post_model.hero = header.match(/hero:\s*(.*)(\r\n|\r|\n)/).captures.first
+      post_model.overlay = header.match(/overlay:\s*(.*)(\r\n|\r|\n)/).captures.first
     end
   end
 end

--- a/app/factories/post_factory.rb
+++ b/app/factories/post_factory.rb
@@ -3,17 +3,18 @@ require_relative '../models/post'
 ##
 # This module is a factory for parsing post text and creating a correseponding post model
 module PostFactory
-  LEAD = '{: .lead}'
-  BREAK = '<!–-break-–>'
-
   class << self
+    LEAD = '{: .lead}'
+    BREAK = '<!–-break-–>'
+
     ##
     # This method parses markdown in a post a returns a post model
     # 
     # Params:
     # +post_contents+::markdown in a given post
-    def create_post(post_contents)      
-      return create_post_model(post_contents) if !post_contents.nil? && post_contents.is_a?(String)
+    # +file_path+::the path on GitHub to the post
+    def create_post(post_contents, file_path)      
+      return create_post_model(post_contents, file_path) if !post_contents.nil? && post_contents.is_a?(String)
     end
 
   private
@@ -26,8 +27,10 @@ module PostFactory
       result.join(', ')
     end
 
-    def create_post_model(post_contents)
+    def create_post_model(post_contents, file_path)
       result = Post.new
+
+      result.file_path = file_path
 
       # What this regular expression does is it matches two groups
       # The first group represents the header of the post which appears

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,0 @@
-##
-# Currently unused Applicaiton Helper
-module ApplicationHelper
-end

--- a/app/helpers/post_helper.rb
+++ b/app/helpers/post_helper.rb
@@ -11,4 +11,12 @@ module PostHelper
     return "/post/submit?path=#{post_path}" if post_path
     '/post/submit'
   end
+
+  def get_selected_overlay(post_overlay)
+    if post_overlay
+      return 'Red' if post_overlay.downcase == 'red'
+      return 'Blue' if post_overlay.downcase == 'blue'
+      return 'Green' if post_overlay.downcase == 'green'
+    end
+  end
 end

--- a/app/helpers/post_helper.rb
+++ b/app/helpers/post_helper.rb
@@ -12,6 +12,11 @@ module PostHelper
     '/post/submit'
   end
 
+  ##
+  # Returns the valid selected value for the overlay dropdown given an existing post's overlay
+  #
+  # Params:
+  # +post_overlay+::the overlay for an existing post
   def get_selected_overlay(post_overlay)
     if post_overlay
       return 'Red' if post_overlay.downcase == 'red'

--- a/app/helpers/post_helper.rb
+++ b/app/helpers/post_helper.rb
@@ -1,0 +1,14 @@
+##
+# A helper module contains helpers for PostController views
+module PostHelper
+  ##
+  # Formats the form url for post submission. If it's an existing post a path parameter
+  # will be added to the url. There will be no url parameters otherwise
+  #
+  # Params:
+  # +post_path+::a path to an existing post on the website
+  def get_post_submission_url(post_path)
+    return "/post/submit?path=#{post_path}" if post_path
+    '/post/submit'
+  end
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -7,4 +7,5 @@ class Post
   attr_accessor :overlay
   attr_accessor :contents
   attr_accessor :tags
+  attr_accessor :file_path
 end

--- a/app/services/github_service.rb
+++ b/app/services/github_service.rb
@@ -74,7 +74,7 @@ module GithubService
         # Base64.decode64 will convert our string into a ASCII string
         # calling force_encoding('UTF-8') will fix that problem
         text_contents = Base64.decode64(post_api_response.content).force_encoding('UTF-8')
-        result << PostFactory.create_post(text_contents)
+        result << PostFactory.create_post(text_contents, post.path)
       end
       result
     end

--- a/app/services/github_service.rb
+++ b/app/services/github_service.rb
@@ -71,7 +71,9 @@ module GithubService
       posts = client.contents(full_repo_name, path: '_posts')
       posts.each do |post|
         post_api_response = client.contents(full_repo_name, path: post.path)
-        text_contents = Base64.decode64(post_api_response.content)
+        # Base64.decode64 will convert our string into a ASCII string
+        # calling force_encoding('UTF-8') will fix that problem
+        text_contents = Base64.decode64(post_api_response.content).force_encoding('UTF-8')
         result << PostFactory.create_post(text_contents)
       end
       result

--- a/app/services/post_service.rb
+++ b/app/services/post_service.rb
@@ -4,6 +4,8 @@ require 'base64'
 # This module contains operations related to posts on the SSE website
 module PostService
   class << self
+    PULL_REQUEST_BODY = 'This pull request was opened automatically by the jekyll-post-editor.'
+
     ##
     # This method submits a post to GitHub by checking out a new branch for the post,
     # if the branch already doesn't exist Commiting and pushing the markdown and any photos 
@@ -13,40 +15,58 @@ module PostService
     # Params
     # +oauth_token+::a user's oauth access token
     # +post_markdown+:: the markdown contents of a post
-    def submit_post(oauth_token, post_markdown, post_title)
+    def create_post(oauth_token, post_markdown, post_title)
       # This ref_name variable represents the branch name
-      # for submiting a post. At the end we strip out all of the whitespace in 
+      # for creating a post. At the end we strip out all of the whitespace in 
       # the post_title to create a valid branch name
       branch_name = "createPost#{post_title.gsub(/\s+/, '')}"
-      new_ref = "heads/#{branch_name}"
-
-      pull_request_body = 'This pull request was opened automatically by the jekyll-post-editor.'
+      ref_name = "heads/#{branch_name}"
 
       master_head_sha = GithubService.get_master_head_sha(oauth_token)
       sha_base_tree = GithubService.get_base_tree_for_branch(oauth_token, master_head_sha)
 
-      GithubService.create_ref_if_necessary(oauth_token, new_ref, master_head_sha)
+      GithubService.create_ref_if_necessary(oauth_token, ref_name, master_head_sha)
       
-      file_information = [ create_blob_for_post(oauth_token, post_markdown, post_title) ]
-      create_image_blobs(oauth_token, post_markdown, file_information)
-      new_tree_sha = GithubService.create_new_tree_with_blobs(oauth_token, file_information, sha_base_tree)
+      new_post_path = create_new_filepath_for_post(post_title)
+      new_tree_sha = create_new_tree(oauth_token, post_markdown, post_title, new_post_path, sha_base_tree)
       
       GithubService.commit_and_push_to_repo(oauth_token, "Created post #{post_title}", 
-                                            new_tree_sha, master_head_sha, new_ref)
+                                            new_tree_sha, master_head_sha, ref_name)
       GithubService.create_pull_request(oauth_token, branch_name, 'master', "Created Post #{post_title}", 
-                                        pull_request_body, [Rails.configuration.webmaster_github_username])
+                                       PULL_REQUEST_BODY, [Rails.configuration.webmaster_github_username])
+      
+      PostImageManager.instance.clear
+    end
+
+    def edit_post(oauth_token, post_markdown, post_title, existing_post_file_path)
+      # This ref_name variable represents the branch name
+      # for editing a post. At the end we strip out all of the whitespace in 
+      # the post_title to create a valid branch name
+      branch_name = "editPost#{post_title.gsub(/\s+/, '')}"
+      ref_name = "heads/#{branch_name}"
+
+      master_head_sha = GithubService.get_master_head_sha(oauth_token)
+      sha_base_tree = GithubService.get_base_tree_for_branch(oauth_token, master_head_sha)
+
+      GithubService.create_ref_if_necessary(oauth_token, ref_name, master_head_sha)
+      new_tree_sha = create_new_tree(oauth_token, post_markdown, post_title, existing_post_file_path, sha_base_tree)
+
+      GithubService.commit_and_push_to_repo(oauth_token, "Edited post #{post_title}", 
+                                            new_tree_sha, master_head_sha, ref_name)
+      GithubService.create_pull_request(oauth_token, branch_name, 'master', "Edited Post #{post_title}", 
+                                        PULL_REQUEST_BODY, [Rails.configuration.webmaster_github_username])
       
       PostImageManager.instance.clear
     end
 
     private
-      def create_new_filename_for_post(post_title)
+      def create_new_filepath_for_post(post_title)
         "_posts/#{DateTime.now.strftime('%Y-%m-%d')}-#{post_title.gsub(/\s+/, '')}.md"
       end
 
-      def create_blob_for_post(oauth_token, post_markdown, post_title)
+      def create_blob_for_post(oauth_token, post_markdown, post_title, post_file_path)
         blob_sha = GithubService.create_text_blob(oauth_token, post_markdown)
-        { path: create_new_filename_for_post(post_title), blob_sha: blob_sha }
+        { path: post_file_path, blob_sha: blob_sha }
       end
 
       def create_image_blobs(oauth_token, post_markdown, current_file_information)
@@ -59,6 +79,12 @@ module PostService
             current_file_information << { path: "assets/img/#{uploader.filename}", blob_sha: image_blob_sha }
           end
         end
+      end
+
+      def create_new_tree(oauth_token, post_markdown, post_title, post_file_path, sha_base_tree)
+        file_information = [ create_blob_for_post(oauth_token, post_markdown, post_title, post_file_path) ]
+        create_image_blobs(oauth_token, post_markdown, file_information)
+        GithubService.create_new_tree_with_blobs(oauth_token, file_information, sha_base_tree)
       end
   end
 end

--- a/app/services/post_service.rb
+++ b/app/services/post_service.rb
@@ -7,8 +7,8 @@ module PostService
     PULL_REQUEST_BODY = 'This pull request was opened automatically by the jekyll-post-editor.'
 
     ##
-    # This method submits a post to GitHub by checking out a new branch for the post,
-    # if the branch already doesn't exist Commiting and pushing the markdown and any photos 
+    # This method submits a new post to GitHub by checking out a new branch for the post,
+    # if the branch already doesn't exist. Commiting and pushing the markdown and any photos 
     # attached to the post to the branch. And then finally opening a pull request into master 
     # for the new post. The SSE webmaster will be requested for review on the created pull request
     #
@@ -38,6 +38,17 @@ module PostService
       PostImageManager.instance.clear
     end
 
+    ##
+    # This method submits changes to an existing post to GitHub by checking out a new branch for the post,
+    # if the branch already doesn't exist. Commiting and pushing the markdown changes and any added photos
+    # for the existing post to the branch. And the finally opening a pull request into master for the new post.
+    # The SSE webmaster will be requested for review on the created pull request
+    #
+    # Params
+    # +oauth_token+::a user's oauth access token
+    # +post_markdown+::the modified markdown to submit
+    # +post_title+::the title for the existing post
+    # +existing_post_file_path+::the file path to the existing post on GitHub
     def edit_post(oauth_token, post_markdown, post_title, existing_post_file_path)
       # This ref_name variable represents the branch name
       # for editing a post. At the end we strip out all of the whitespace in 

--- a/app/views/post/edit.html.erb
+++ b/app/views/post/edit.html.erb
@@ -19,7 +19,7 @@
         <%= text_field_tag(:tags, @post.tags) %>
         <%= simple_format("\n") %>
         <%= label_tag('Overlay:') %>
-        <%= select_tag('overlay', raw('<option>Red</option><option>Blue</option><option>Green</option>')) %>
+        <%= select_tag('overlay', options_for_select(['Red', 'Blue', 'Green'], get_selected_overlay(@post.overlay))) %>
       <% end %>
       <%= content_tag(:div, id: 'tab-container') do %>
         <%= button_tag('Markdown', id: 'markdown-button', type: 'button') %>

--- a/app/views/post/edit.html.erb
+++ b/app/views/post/edit.html.erb
@@ -1,5 +1,5 @@
 <%= javascript_include_tag 'postEdit', 'data-turbolinks-track': 'reload' %>
-<%= form_tag('/post/submit', method: 'post') do %>
+<%= form_tag(get_post_submission_url(@post.file_path), method: 'post') do %>
   <% if flash[:alert] %>
     <%= content_tag :div, flash[:alert], class: 'validation-message' %>
   <% end %>

--- a/test/factories/post_factory_test.rb
+++ b/test/factories/post_factory_test.rb
@@ -43,4 +43,31 @@ overlay: green
     assert_equal 'green', result.overlay
     assert_equal "#An H1 tag\n##An H2 tag", result.contents
   end
+
+  test 'create_post should return a post model with correct values given a post with \r\n line breaks' do 
+    # Arrange
+    post_contents = %(---
+layout: post\r
+title: Some Post\r
+author: Andrew Wojciechowski\r
+tags:\r
+  - announcement\r
+  - info\r
+hero: https://source.unsplash.com/collection/145103/\r
+overlay: green\r
+---\r
+#An H1 tag\r
+##An H2 tag)
+        
+    # Act
+    result = PostFactory.create_post(post_contents)
+        
+    # Assert
+    assert_equal "Some Post\r", result.title
+    assert_equal "Andrew Wojciechowski\r", result.author
+    assert_equal "announcement\r, info\r", result.tags
+    assert_equal "https://source.unsplash.com/collection/145103/\r", result.hero
+    assert_equal "green\r", result.overlay
+    assert_equal "#An H1 tag\r\n##An H2 tag", result.contents
+  end
 end

--- a/test/factories/post_factory_test.rb
+++ b/test/factories/post_factory_test.rb
@@ -1,6 +1,9 @@
 require 'test_helper'
 
 class PostFactoryTest < ActiveSupport::TestCase
+  LEAD_BREAK_SECTION1 = "{: .lead}\r\n<!–-break-–>"
+  LEAD_BREAK_SECTION2 = "{: .lead}\n<!–-break-–>"
+
   test 'create_post should return nil if given a nil value for post_contents' do 
     # Act
     result = PostFactory.create_post(nil)
@@ -29,6 +32,7 @@ tags:
 hero: https://source.unsplash.com/collection/145103/
 overlay: green
 ---
+#{LEAD_BREAK_SECTION1}
 #An H1 tag
 ##An H2 tag)
 
@@ -56,6 +60,7 @@ tags:\r
 hero: https://source.unsplash.com/collection/145103/\r
 overlay: green\r
 ---\r
+#{LEAD_BREAK_SECTION2}
 #An H1 tag\r
 ##An H2 tag)
         

--- a/test/factories/post_factory_test.rb
+++ b/test/factories/post_factory_test.rb
@@ -6,7 +6,7 @@ class PostFactoryTest < ActiveSupport::TestCase
 
   test 'create_post should return nil if given a nil value for post_contents' do 
     # Act
-    result = PostFactory.create_post(nil)
+    result = PostFactory.create_post(nil, nil)
 
     # Assert
     assert_nil result
@@ -14,7 +14,7 @@ class PostFactoryTest < ActiveSupport::TestCase
 
   test 'create_post should return nil if given a non-string type for post_contents' do
     # Act
-    result = PostFactory.create_post(1)
+    result = PostFactory.create_post(1, 'my post.md')
 
     # Assert
     assert_nil result
@@ -37,9 +37,10 @@ overlay: green
 ##An H2 tag)
 
     # Act
-    result = PostFactory.create_post(post_contents)
+    result = PostFactory.create_post(post_contents, 'my post.md')
 
     # Assert
+    assert_equal 'my post.md', result.file_path
     assert_equal 'Some Post', result.title
     assert_equal 'Andrew Wojciechowski', result.author
     assert_equal 'announcement, info', result.tags
@@ -65,9 +66,10 @@ overlay: green\r
 ##An H2 tag)
         
     # Act
-    result = PostFactory.create_post(post_contents)
+    result = PostFactory.create_post(post_contents, 'my post.md')
         
     # Assert
+    assert_equal 'my post.md', result.file_path
     assert_equal "Some Post\r", result.title
     assert_equal "Andrew Wojciechowski\r", result.author
     assert_equal "announcement\r, info\r", result.tags

--- a/test/helpers/post_helper_test.rb
+++ b/test/helpers/post_helper_test.rb
@@ -18,4 +18,36 @@ class PostHelperTest < ActiveSupport::TestCase
     # Assert
     assert_equal '/post/submit?path=my-path', result
   end
+
+  test 'get_selected_overlay should return Red if the overlay passed in matches red in any case' do 
+    # Arrange
+    result = get_selected_overlay('REd')
+
+    # Assert
+    assert_equal 'Red', result
+  end
+
+  test 'get_selected_overlay should return Blue if the overlay passed in matches blue in any case' do 
+    # Arrange
+    result = get_selected_overlay('BLUe')
+
+    # Assert
+    assert_equal 'Blue', result
+  end
+
+  test 'get_selected_overlay should return Green if the overlay passed in matches green in any case' do 
+    # Arrange
+    result = get_selected_overlay('GREen')
+
+    # Assert
+    assert_equal 'Green', result
+  end
+
+  test 'get_selected_overlay should return nil if the overlay does not match red, blue, or green' do 
+    # Arrange
+    result = get_selected_overlay('Aqua Marine')
+
+    # Assert
+    assert_nil result
+  end
 end

--- a/test/helpers/post_helper_test.rb
+++ b/test/helpers/post_helper_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+
+class PostHelperTest < ActiveSupport::TestCase
+  include PostHelper
+
+  test 'get_post_submission_url should not add a path url parameter given a nil path' do 
+    # Act
+    result = get_post_submission_url(nil)
+
+    # Assert
+    assert_equal '/post/submit', result
+  end
+
+  test 'get_post_submission_url should add a path url parameter given a path as a string' do 
+    # Arrange
+    result = get_post_submission_url('my-path')
+
+    # Assert
+    assert_equal '/post/submit?path=my-path', result
+  end
+end

--- a/test/integration/error_test.rb
+++ b/test/integration/error_test.rb
@@ -6,7 +6,7 @@ class ErrorTest < BaseIntegrationTest
     setup_session('access token', true)
     GithubService.expects(:check_sse_github_org_membership).with('access token').returns(true)
 
-    PostService.expects(:submit_post).with('access token', 'post text', 'title').raises(Octokit::TooManyRequests)
+    PostService.expects(:create_post).with('access token', 'post text', 'title').raises(Octokit::TooManyRequests)
     KramdownService.expects(:create_jekyll_post_text)
                    .with('# hello', 'author', 'title', 'tags', 'red').returns('post text')
             

--- a/test/integration/post_controller_test.rb
+++ b/test/integration/post_controller_test.rb
@@ -196,12 +196,12 @@ class PostControllerTest < BaseIntegrationTest
     assert_nil flash[:notice]
   end
 
-  test 'post/submit should submit the post to GitHub and redirect back to the edit screen with a valid post' do 
+  test 'post/submit should submit the new post to GitHub and redirect back to the edit screen with a valid post' do 
     # Arrange
     setup_session('access token', true)
     GithubService.expects(:check_sse_github_org_membership).with('access token').returns(true)
 
-    PostService.expects(:submit_post).with('access token', 'post text', 'title').once
+    PostService.expects(:create_post).with('access token', 'post text', 'title').once
     KramdownService.expects(:create_jekyll_post_text)
                    .with('# hello', 'author', 'title', 'tags', 'red').returns('post text')
             
@@ -209,6 +209,26 @@ class PostControllerTest < BaseIntegrationTest
     post '/post/submit', params: { title: 'title', author: 'author', 
                                    markdownArea: '# hello', tags: 'tags', overlay: 'red' }
             
+    # Assert
+    assert_redirected_to '/post/edit'
+    assert_nil flash[:alert]
+    assert_equal 'Post Successfully Submited', flash[:notice]
+  end
+
+  test 'post/submit? should submit the existing post to GitHub 
+        and redirect back to the edit screen with a valid post' do 
+    # Arrange
+    setup_session('access token', true)
+    GithubService.expects(:check_sse_github_org_membership).with('access token').returns(true)
+
+    PostService.expects(:edit_post).with('access token', 'post text', 'title', 'path.md').once
+    KramdownService.expects(:create_jekyll_post_text)
+                   .with('# hello', 'author', 'title', 'tags', 'red').returns('post text')
+
+    # Act
+    post '/post/submit?path=path.md', params: { title: 'title', author: 'author', 
+                                                markdownArea: '# hello', tags: 'tags', overlay: 'red' }
+
     # Assert
     assert_redirected_to '/post/edit'
     assert_nil flash[:alert]

--- a/test/services/github_service_test.rb
+++ b/test/services/github_service_test.rb
@@ -110,9 +110,9 @@ class GithubServiceTest < ActiveSupport::TestCase
     Base64.expects(:decode64).with('post 2 base 64 content').returns('post 2 text content')
     Base64.expects(:decode64).with('post 3 base 64 content').returns('post 3 text content')
     
-    PostFactory.expects(:create_post).with('post 1 text content').returns(post1_model)
-    PostFactory.expects(:create_post).with('post 2 text content').returns(post2_model)
-    PostFactory.expects(:create_post).with('post 3 text content').returns(post3_model)
+    PostFactory.expects(:create_post).with('post 1 text content', '_posts/post1.md').returns(post1_model)
+    PostFactory.expects(:create_post).with('post 2 text content', '_posts/post2.md').returns(post2_model)
+    PostFactory.expects(:create_post).with('post 3 text content', '_posts/post3.md').returns(post3_model)
 
     # Act
     result = GithubService.get_all_posts('my token')

--- a/test/services/post_service_test.rb
+++ b/test/services/post_service_test.rb
@@ -178,8 +178,8 @@ class PostServiceTest < ActiveSupport::TestCase
                                           create_mock_carrierware_file('C:\post_image-My Image 1.jpg'))
     post_image_uploader = create_post_image_uploader('My Image 1.jpg', mock_uploader)
 
-    KramdownService.expects(:does_markdown_include_image)
-                   .with('My Image 1.jpg', test_markdown).returns(true)
+    KramdownService.expects(:get_image_filename_from_markdown)
+                   .with('My Image 1.jpg', test_markdown).returns('My Image 1.jpg')
 
     image_blob_sha = mock_image_blob_and_return_sha(post_image_uploader)
     PostImageManager.instance.expects(:uploaders).returns([ post_image_uploader ])


### PR DESCRIPTION
This PR includes the finalized initial implementation of post editing besides limiting editing to posts that someone else has written. So, now we're able to click on existing post, edit it, and the changes will get submitted to GitHub. This PR also includes some fixes to some issues that were discovered during development.

-When parsing existing posts it will be able to parse posts with \r\n and \n newlines.
-Forced the post contents to be encoded as UTF-8 in the response from the GitHub API I ran into an issue with my parsing code where I had some regex breaking due to the string originally being encoded as ASCII from GitHub.

Note this includes the first time I wrote a "helper".A helper in rails is a place to put helper methods for views so that views won't be cluttered with complex logic and so that we can test those helper methods.

I'd say lets get this reviewed during the next SSE website meeting on 8/14 but feel free to look at it before hand if you have the time.