### PR TITLE
Added the read:org scope to the GitHub authorize url

### DIFF
--- a/app/services/github_service.rb
+++ b/app/services/github_service.rb
@@ -13,7 +13,7 @@ module GithubService
     # This method get the authorization url which authorizes the post editor app
     # to use a user's GitHub account. The scopes public_repo is used so that we're able
     # to make changes to the msoe-sse/mseo-sse.github.io repository which requires
-    # access a user's public repositories. Also, the scope read:org is used so that
+    # access to a user's public repositories. Also, the scope read:org is used so that
     # we can read public and private org membership
     def get_authorization_url
       client = Octokit::Client.new

--- a/app/services/github_service.rb
+++ b/app/services/github_service.rb
@@ -11,12 +11,13 @@ module GithubService
 
     ##
     # This method get the authorization url which authorizes the post editor app
-    # to use a user's GitHub account. The scope is public_repo so that we're able
+    # to use a user's GitHub account. The scopes public_repo is used so that we're able
     # to make changes to the msoe-sse/mseo-sse.github.io repository which requires
-    # access a user's public repositories
+    # access a user's public repositories. Also, the scope read:org is used so that
+    # we can read public and private org membership
     def get_authorization_url
       client = Octokit::Client.new
-      client.authorize_url(CLIENT_ID, scope: 'public_repo')
+      client.authorize_url(CLIENT_ID, scope: 'public_repo read:org')
     end
 
     ##

--- a/test/integration/post_controller_test.rb
+++ b/test/integration/post_controller_test.rb
@@ -40,7 +40,7 @@ class PostControllerTest < BaseIntegrationTest
     get '/post/list'
 
     # Assert
-    assert_redirected_to 'https://github.com/login/oauth/authorize?client_id=github client id&scope=public_repo'
+    assert_redirected_to 'https://github.com/login/oauth/authorize?client_id=github client id&scope=public_repo+read%3Aorg'
   end
 
   test 'an unauthenticated user should be redirected to GitHub when navigating to /' do
@@ -48,7 +48,7 @@ class PostControllerTest < BaseIntegrationTest
     get '/'
 
     # Assert
-    assert_redirected_to 'https://github.com/login/oauth/authorize?client_id=github client id&scope=public_repo'
+    assert_redirected_to 'https://github.com/login/oauth/authorize?client_id=github client id&scope=public_repo+read%3Aorg'
   end
 
   test 'an authenticated user should be able to navigate to post/edit successfully' do 
@@ -81,7 +81,7 @@ class PostControllerTest < BaseIntegrationTest
     GithubService.expects(:check_sse_github_org_membership).never
 
     # Assert
-    assert_redirected_to 'https://github.com/login/oauth/authorize?client_id=github client id&scope=public_repo'
+    assert_redirected_to 'https://github.com/login/oauth/authorize?client_id=github client id&scope=public_repo+read%3Aorg'
   end
 
   test 'an authenticated user with an expired token should be redirected to GitHub when navigating to post/edit' do 
@@ -93,7 +93,7 @@ class PostControllerTest < BaseIntegrationTest
     get '/post/edit'
 
     # Assert
-    assert_redirected_to 'https://github.com/login/oauth/authorize?client_id=github client id&scope=public_repo'
+    assert_redirected_to 'https://github.com/login/oauth/authorize?client_id=github client id&scope=public_repo+read%3Aorg'
   end
 
   test 'an authenticated user should be able to navigate to post/edit successfully with a title parameter' do

--- a/test/integration/post_controller_test.rb
+++ b/test/integration/post_controller_test.rb
@@ -36,19 +36,25 @@ class PostControllerTest < BaseIntegrationTest
   end
 
   test 'an unauthenticated user should be redirected to GitHub when navigating to post/list' do
+    # Arrange
+    auth_url = 'https://github.com/login/oauth/authorize?client_id=github client id&scope=public_repo+read%3Aorg'
+
     # Act
     get '/post/list'
 
     # Assert
-    assert_redirected_to 'https://github.com/login/oauth/authorize?client_id=github client id&scope=public_repo+read%3Aorg'
+    assert_redirected_to auth_url
   end
 
   test 'an unauthenticated user should be redirected to GitHub when navigating to /' do
+    # Arrange
+    auth_url = 'https://github.com/login/oauth/authorize?client_id=github client id&scope=public_repo+read%3Aorg'
+
     # Act
     get '/'
 
     # Assert
-    assert_redirected_to 'https://github.com/login/oauth/authorize?client_id=github client id&scope=public_repo+read%3Aorg'
+    assert_redirected_to auth_url
   end
 
   test 'an authenticated user should be able to navigate to post/edit successfully' do 
@@ -76,24 +82,28 @@ class PostControllerTest < BaseIntegrationTest
   end
 
   test 'an unauthenticated user should be redirected to GitHub when navigating to post/edit' do
-    # Act
-    get '/post/edit'
+    # Arrange
+    auth_url = 'https://github.com/login/oauth/authorize?client_id=github client id&scope=public_repo+read%3Aorg'
     GithubService.expects(:check_sse_github_org_membership).never
 
+    # Act
+    get '/post/edit'
+
     # Assert
-    assert_redirected_to 'https://github.com/login/oauth/authorize?client_id=github client id&scope=public_repo+read%3Aorg'
+    assert_redirected_to  auth_url
   end
 
   test 'an authenticated user with an expired token should be redirected to GitHub when navigating to post/edit' do 
     # Arrange
     setup_session('access token', false)
+    auth_url = 'https://github.com/login/oauth/authorize?client_id=github client id&scope=public_repo+read%3Aorg'
     GithubService.expects(:check_sse_github_org_membership).never
 
     # Act
     get '/post/edit'
 
     # Assert
-    assert_redirected_to 'https://github.com/login/oauth/authorize?client_id=github client id&scope=public_repo+read%3Aorg'
+    assert_redirected_to auth_url
   end
 
   test 'an authenticated user should be able to navigate to post/edit successfully with a title parameter' do

--- a/test/services/github_service_test.rb
+++ b/test/services/github_service_test.rb
@@ -8,13 +8,15 @@ class GithubServiceTest < ActiveSupport::TestCase
   # Note the client id and client secret values are set in test_helper.rb
   test 'get_authorization_url should get the correct authorization url with the public_repo scope' do 
     # Arrange
-    Octokit::Client.any_instance.expects(:authorize_url).with('github client id', scope: 'public_repo read:org').returns('https://github.com/login/oauth/authorize?client_id=github client id&scope=public_repo+read%3Aorg')
+    auth_url = 'https://github.com/login/oauth/authorize?client_id=github client id&scope=public_repo+read%3Aorg'
+    Octokit::Client.any_instance.expects(:authorize_url)
+                   .with('github client id', scope: 'public_repo read:org').returns(auth_url)
 
     # Act
     result = GithubService.get_authorization_url
 
     # Assert
-    assert_equal 'https://github.com/login/oauth/authorize?client_id=github client id&scope=public_repo+read%3Aorg', result
+    assert_equal auth_url, result
   end
 
   test 'get_oauth_access_token should return a oauth access token for a GitHub user' do 

--- a/test/services/github_service_test.rb
+++ b/test/services/github_service_test.rb
@@ -8,13 +8,13 @@ class GithubServiceTest < ActiveSupport::TestCase
   # Note the client id and client secret values are set in test_helper.rb
   test 'get_authorization_url should get the correct authorization url with the public_repo scope' do 
     # Arrange
-    Octokit::Client.any_instance.expects(:authorize_url).with('github client id', scope: 'public_repo').returns('https://github.com/login/oauth/authorize?scope=public_repo&client_id=github%20client%20id')
+    Octokit::Client.any_instance.expects(:authorize_url).with('github client id', scope: 'public_repo read:org').returns('https://github.com/login/oauth/authorize?client_id=github client id&scope=public_repo+read%3Aorg')
 
     # Act
     result = GithubService.get_authorization_url
 
     # Assert
-    assert_equal 'https://github.com/login/oauth/authorize?scope=public_repo&client_id=github%20client%20id', result
+    assert_equal 'https://github.com/login/oauth/authorize?client_id=github client id&scope=public_repo+read%3Aorg', result
   end
 
   test 'get_oauth_access_token should return a oauth access token for a GitHub user' do 


### PR DESCRIPTION
What the read:org scope allows us to do is to access a user's public and private GitHub org membership. Joesph was running into issues yesterday where the post editor detected that he wasn't a member of the SSE GitHub org and this was fixed by changing his membership from private to public. To avoid the extra step of having everyone switch their membership to public I thought it would just be easier to add this scope to handle both public and private members.