### PR TITLE
Only allow users to see posts if they've created them

### DIFF
--- a/app/assets/stylesheets/styles/post/edit.scss
+++ b/app/assets/stylesheets/styles/post/edit.scss
@@ -82,3 +82,10 @@ label {
 .overlayDropdown {
   width: 150px;
 }
+
+.noPostsMessage {
+  font-size: 20px;
+  display: flex;
+  justify-content: center;
+  margin-top: 1rem;
+}

--- a/app/services/github_service.rb
+++ b/app/services/github_service.rb
@@ -62,7 +62,9 @@ module GithubService
 
     ##
     # This method fetches all the markdown contents of all the posts on the SSE website
-    # and returns a list of models representing a Post
+    # that a user has written and returns a list of models representing a Post. A user is determined
+    # to have written a post if the oldest commit for a post matches the current authenticated GitHub
+    # user.
     #
     # Params:
     # +oauth_token+::a user's oauth access token

--- a/app/services/github_service.rb
+++ b/app/services/github_service.rb
@@ -72,8 +72,8 @@ module GithubService
       posts = client.contents(full_repo_name, path: '_posts')
       posts.each do |post|
         oldest_commit = get_oldest_commit_for_file(client, post.path)
-        
-        if client.user == oldest_commit[:author][:login]
+
+        if client.user[:login] == oldest_commit[:author][:login]
           post_api_response = client.contents(full_repo_name, path: post.path)
           # Base64.decode64 will convert our string into a ASCII string
           # calling force_encoding('UTF-8') will fix that problem

--- a/app/views/post/list.html.erb
+++ b/app/views/post/list.html.erb
@@ -13,7 +13,7 @@
           <% concat(content_tag(:li, link_to(post.title, { controller: 'post', action: 'edit', title: post.title }) )) %>
         <% end %>
       <% else %>
-        <%= content_tag(:div, 'No posts are available to edit', class: 'noPostsMessage') %>
+        <%= content_tag(:div, 'No previously created posts.', class: 'noPostsMessage') %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/post/list.html.erb
+++ b/app/views/post/list.html.erb
@@ -8,8 +8,12 @@
       <% end %>
     <% end %>
     <%= content_tag(:ul, class: 'postList') do %>
-      <% @posts.each do |post| %>
-        <% concat(content_tag(:li, link_to(post.title, { controller: 'post', action: 'edit', title: post.title }) )) %>
+      <% if @posts.length > 0 %>
+        <% @posts.each do |post| %>
+          <% concat(content_tag(:li, link_to(post.title, { controller: 'post', action: 'edit', title: post.title }) )) %>
+        <% end %>
+      <% else %>
+        <%= content_tag(:div, 'No posts are available to edit', class: 'noPostsMessage') %>
       <% end %>
     <% end %>
   <% end %>

--- a/test/services/github_service_test.rb
+++ b/test/services/github_service_test.rb
@@ -109,7 +109,7 @@ class GithubServiceTest < ActiveSupport::TestCase
                                 .with('msoe-sse/jekyll-post-editor-test-repo', path: '_posts/post3.md')
                                 .returns([ create_commit_hash('2011-04-14T16:00:49Z', 'andy-wojciechowski') ])
 
-    Octokit::Client.any_instance.expects(:user).returns({ login: 'andy-wojciechowski' }).at_least_once
+    Octokit::Client.any_instance.expects(:user).returns(login: 'andy-wojciechowski').at_least_once
 
     Octokit::Client.any_instance.expects(:contents)
                    .with('msoe-sse/jekyll-post-editor-test-repo', path: '_posts')


### PR DESCRIPTION
This was implemented using the GitHub commits API. There was the option to get a list of commits for a specific file. I determined if the user created that post if the user with the oldest commit for that post matches the current authenticated user in the post editor.

Also, if a user has not created any posts previously the message "No previously created posts" will show in the list view instead of showing nothing. If you have a better idea for what that message should be, please leave a comment and I'll change that message.