### PR TITLE
Fixed authorization on the ImageController

### DIFF
--- a/app/controllers/image_controller.rb
+++ b/app/controllers/image_controller.rb
@@ -3,7 +3,9 @@
 # Note: this should really inherit from BasePostEditorController but doesn't
 # since this controller makes AJAX POST requests which won't save the session[:access_token]
 # variable
-class ImageController < ApplicationController
+class ImageController < BasePostEditorController
+  skip_before_action :verify_authenticity_token
+
   # POST image/upload
   def upload
     PostImageManager.instance.add_file(params[:file])

--- a/app/controllers/image_controller.rb
+++ b/app/controllers/image_controller.rb
@@ -1,8 +1,5 @@
 ##
-# This controller deals with routes for attaching photos to an SSE post
-# Note: this should really inherit from BasePostEditorController but doesn't
-# since this controller makes AJAX POST requests which won't save the session[:access_token]
-# variable
+# This controller deals with routes for attaching photos to an SSE posts
 class ImageController < BasePostEditorController
   skip_before_action :verify_authenticity_token
 

--- a/test/integration/base_integration_test.rb
+++ b/test/integration/base_integration_test.rb
@@ -7,7 +7,8 @@ class BaseIntegrationTest < ActionDispatch::IntegrationTest
   protected
     def setup_session(access_token, is_valid_token)
       session = { access_token: access_token }
-      PostController.any_instance.expects(:session).at_least_once.returns(session)
+      PostController.any_instance.expects(:session).at_least(0).returns(session)
+      ImageController.any_instance.expects(:session).at_least(0).returns(session)
       GithubService.expects(:check_access_token).with(access_token).returns(is_valid_token)
     end
 end

--- a/test/integration/image_controller_test.rb
+++ b/test/integration/image_controller_test.rb
@@ -3,6 +3,9 @@ require 'test_helper'
 class ImageControllerTest < BaseIntegrationTest
   test 'upload should return a 200 ok response' do 
     # Arrange
+    setup_session('access token', true)
+    GithubService.expects(:check_sse_github_org_membership).with('access token').returns(true)
+
     PostImageManager.instance.expects(:add_file).with('dummy file object').once
 
     # Act


### PR DESCRIPTION
This fixes issue #41 

This controller has an action which handles a user dragging and dropping an image onto the editor. Before this wasn't inheriting from the BasePostEditorController since it couldn't access the GitHub auth token stored in the session. I fixed that by disabling cross-site-request-forgery token checks for the image controller, and only for that controller. It makes sense to disable that since this controller only has AJAX actions and is more useful on controller methods which actually lead to a page on the site.