### PR TITLE
Added handling if the first line in a user's markdown is a link reference

### DIFF
--- a/app/services/kramdown_service.rb
+++ b/app/services/kramdown_service.rb
@@ -65,6 +65,8 @@ module KramdownService
     # +overlay+:: the overlay color of the post
     def create_jekyll_post_text(text, author, title, tags, overlay, hero)
       header_converted_text = fix_header_syntax(text)
+      header_converted_text = add_line_break_to_markdown_if_necessary(header_converted_text)
+      
       parsed_tags = parse_tags(tags)
 
       tag_section = %(tags:
@@ -127,6 +129,17 @@ published: true
 
       def get_filename_for_image_tag(image_el)
         File.basename(image_el.attr['src'])
+      end
+
+      def add_line_break_to_markdown_if_necessary(markdown)
+        lines = markdown.split("\n")
+        # The regular expression in the if statement looks for a markdown reference to a link like
+        # [logo]: https://ieeextreme.org/wp-content/uploads/2019/05/Xtreme_colour-e1557478323964.png
+        # If a post starts with that reference in jekyll followed by an image using that reference
+        # the line below will be interperted as a paragraph tag instead of an image tag. To fix that
+        # we add a line break to the start of the markdown.
+        return "\r\n#{markdown}" if lines.first && lines.first.match?(/\[(.*)\]: (.*)/)
+        markdown
       end
   end
 end

--- a/test/services/kramdown_service_test.rb
+++ b/test/services/kramdown_service_test.rb
@@ -243,4 +243,33 @@ published: true
     # Assert
     assert_equal expected_post, result
   end
+
+  test 'create_jekyll_post_text should add a line break before a reference style image 
+        if the markdown starts with a reference style image' do 
+    image_tag = "\r\n![alt text][logo]"
+    markdown = "[logo]: https://ieeextreme.org/wp-content/uploads/2019/05/Xtreme_colour-e1557478323964.png#{image_tag}"
+
+    # Arrange
+    expected_post = %(---
+layout: post
+title: Some Post
+author: Andy Wojciechowski\r
+tags:
+  - announcement\r
+  - info\r
+hero: bonk
+overlay: green
+published: true
+---
+#{LEAD_BREAK_SECTION}
+\r
+#{markdown})
+
+    # Act
+    result = KramdownService.create_jekyll_post_text(markdown, 'Andy Wojciechowski', 'Some Post', 
+                                                    'announcement, info', 'green', 'bonk')
+
+    # Assert
+    assert_equal expected_post, result
+  end
 end


### PR DESCRIPTION
@GFLEMING133 I'm requesting your review on this since this will fix #47 which was the issue that Kiel was running into and I think it would be good for you to see how that issue was resolved.

So, after experimenting with the following markdown below.
[logo]: https://ieeextreme.org/wp-content/uploads/2019/05/Xtreme_colour-e1557478323964.png
![alt text][logo]

I discovered that Jekyll will interpret the first line as a paragraph tag if it's the first line of the markdown. I was able to fix it by adding a line break before the [logo]: https://ieeextreme.org/wp-content/uploads/2019/05/Xtreme_colour-e1557478323964.png line. I'm still confused as to why Jekyll does that and is probably a bug in the Jekyll Framework, but this PR should add a line break as the first line in the markdown if it starts with a link reference.