### PR TITLE
Added the ability to edit posts in PR

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,7 +26,7 @@ Metrics/LineLength:
   Max: 120
 
 Metrics/BlockLength:
-  Max: 50 # This is doubled from the default because our automated tests use blocks instead of methods
+  Max: 75 # This is more than double from the default because our automated tests use blocks instead of methods
 
 Metrics/MethodLength:
   Max: 25

--- a/app/assets/javascripts/postList.js
+++ b/app/assets/javascripts/postList.js
@@ -1,0 +1,5 @@
+$(function () {
+    setTimeout(function() {
+        $(".alert" ).fadeOut(3000);
+    }, 2000);
+});

--- a/app/assets/stylesheets/styles/post/list.scss
+++ b/app/assets/stylesheets/styles/post/list.scss
@@ -24,3 +24,9 @@ h1 {
   float: right;
   margin-top: 24px;
 }
+
+.alert {
+  display: flex;
+  justify-content: center;
+  width: 45rem;
+}

--- a/app/controllers/post_controller.rb
+++ b/app/controllers/post_controller.rb
@@ -5,6 +5,7 @@ require 'uri'
 class PostController < BasePostEditorController
   # GET post/list
   def list
+    PostImageManager.instance.clear
     @pr_posts = GithubService.get_all_posts_in_pr_for_user(session[:access_token])
     @posts = GithubService.get_all_posts(session[:access_token]).select do | post |
       found_post = @pr_posts.find { |x| x.title == post.title }

--- a/app/controllers/post_controller.rb
+++ b/app/controllers/post_controller.rb
@@ -5,8 +5,12 @@ require 'uri'
 class PostController < BasePostEditorController
   # GET post/list
   def list
-    @posts = GithubService.get_all_posts(session[:access_token])
     @pr_posts = GithubService.get_all_posts_in_pr_for_user(session[:access_token])
+    @posts = GithubService.get_all_posts(session[:access_token]).select do | post |
+      found_post = @pr_posts.find { |x| x.title == post.title }
+      post if !found_post
+    end
+    @posts.compact!
   end
   
   # GET post/edit

--- a/app/controllers/post_controller.rb
+++ b/app/controllers/post_controller.rb
@@ -12,7 +12,7 @@ class PostController < BasePostEditorController
   def edit
     @post = Post.new
     create_post_from_session if session[:post_stored]
-    @post = GithubService.get_post_by_title(session[:access_token], params[:title]) if params[:title]
+    @post = GithubService.get_post_by_title(session[:access_token], params[:title], params[:ref]) if params[:title]
   end
 
   # GET post/preview

--- a/app/controllers/post_controller.rb
+++ b/app/controllers/post_controller.rb
@@ -1,4 +1,5 @@
 require 'uri'
+
 ##
 # The controller responsible for dealing with views related to SSE website posts
 class PostController < BasePostEditorController

--- a/app/controllers/post_controller.rb
+++ b/app/controllers/post_controller.rb
@@ -48,7 +48,7 @@ class PostController < BasePostEditorController
         PostService.create_post(session[:access_token], full_post_text, params[:title])
       end
       flash[:notice] = 'Post Successfully Submited'
-      redirect_to action: 'edit'
+      redirect_to action: 'list'
     end
   end
 

--- a/app/controllers/post_controller.rb
+++ b/app/controllers/post_controller.rb
@@ -18,6 +18,8 @@ class PostController < BasePostEditorController
   def edit
     @post = Post.new
     create_post_from_session if session[:post_stored]
+    # The ref parameter is for indicating editing a post that is apart of an open pull request. The ref parameter
+    # itself is a sha pointing to the head of the base branch in that open pull request.
     @post = GithubService.get_post_by_title(session[:access_token], params[:title], params[:ref]) if params[:title]
   end
 

--- a/app/controllers/post_controller.rb
+++ b/app/controllers/post_controller.rb
@@ -34,7 +34,10 @@ class PostController < BasePostEditorController
       full_post_text = KramdownService.create_jekyll_post_text(params[:markdownArea], params[:author], 
                                                                params[:title], params[:tags],
                                                                params[:overlay], params[:hero])
-      if params[:path]
+      
+      if params[:path] && params[:ref]
+        PostService.edit_post_in_pr(session[:access_token], full_post_text, params[:title], params[:path], params[:ref])
+      elsif params[:path]
         PostService.edit_post(session[:access_token], full_post_text, params[:title], params[:path])
       else
         PostService.create_post(session[:access_token], full_post_text, params[:title])

--- a/app/controllers/post_controller.rb
+++ b/app/controllers/post_controller.rb
@@ -5,6 +5,7 @@ class PostController < BasePostEditorController
   # GET post/list
   def list
     @posts = GithubService.get_all_posts(session[:access_token])
+    @pr_posts = GithubService.get_all_posts_in_pr_for_user(session[:access_token])
   end
   
   # GET post/edit

--- a/app/factories/post_factory.rb
+++ b/app/factories/post_factory.rb
@@ -56,6 +56,7 @@ module PostFactory
       post_model.title = header.match(/title:\s*(.*)(\r\n|\r|\n)/).captures.first
       post_model.author = header.match(/author:\s*(.*)(\r\n|\r|\n)/).captures.first
       post_model.hero = header.match(/hero:\s*(.*)(\r\n|\r|\n)/).captures.first
+      post_model.hero = '' if post_model.hero == Rails.configuration.default_hero
       post_model.overlay = header.match(/overlay:\s*(.*)(\r\n|\r|\n)/).captures.first
     end
   end

--- a/app/factories/post_factory.rb
+++ b/app/factories/post_factory.rb
@@ -13,7 +13,7 @@ module PostFactory
     # Params:
     # +post_contents+::markdown in a given post
     # +file_path+::the path on GitHub to the post
-    # +ref+::the ref indicating which branch this post is on GitHub
+    # +ref+::a sha for a ref indicating the head of a branch a post is pushed to on the GitHub server
     def create_post(post_contents, file_path, ref)      
       return create_post_model(post_contents, file_path, ref) if !post_contents.nil? && post_contents.is_a?(String)
     end

--- a/app/factories/post_factory.rb
+++ b/app/factories/post_factory.rb
@@ -13,7 +13,7 @@ module PostFactory
     # Params:
     # +post_contents+::markdown in a given post
     # +file_path+::the path on GitHub to the post
-    # +ref+::the ref where this post is on GitHub
+    # +ref+::the ref indicating which branch this post is on GitHub
     def create_post(post_contents, file_path, ref)      
       return create_post_model(post_contents, file_path, ref) if !post_contents.nil? && post_contents.is_a?(String)
     end

--- a/app/factories/post_factory.rb
+++ b/app/factories/post_factory.rb
@@ -13,8 +13,9 @@ module PostFactory
     # Params:
     # +post_contents+::markdown in a given post
     # +file_path+::the path on GitHub to the post
-    def create_post(post_contents, file_path)      
-      return create_post_model(post_contents, file_path) if !post_contents.nil? && post_contents.is_a?(String)
+    # +ref+::the ref where this post is on GitHub
+    def create_post(post_contents, file_path, ref)      
+      return create_post_model(post_contents, file_path, ref) if !post_contents.nil? && post_contents.is_a?(String)
     end
 
   private
@@ -27,10 +28,11 @@ module PostFactory
       result.join(', ')
     end
 
-    def create_post_model(post_contents, file_path)
+    def create_post_model(post_contents, file_path, ref)
       result = Post.new
 
       result.file_path = file_path
+      result.github_ref = ref
 
       # What this regular expression does is it matches two groups
       # The first group represents the header of the post which appears

--- a/app/factories/post_factory.rb
+++ b/app/factories/post_factory.rb
@@ -34,9 +34,10 @@ module PostFactory
       result.file_path = file_path
       result.github_ref = ref
 
-      # What this regular expression does is it matches two groups
+      # What this regular expression does is it matches three groups
       # The first group represents the header of the post which appears
-      # between the two --- lines. The second group represents the actual post contents
+      # between the two --- lines. The second group is for helping capture newline characters
+      # correctly and the third group is the actual post contents
       match_obj = post_contents.match(/---(.*)---(\r\n|\r|\n)(.*)/m)
       header = match_obj.captures[0]
       

--- a/app/helpers/post_helper.rb
+++ b/app/helpers/post_helper.rb
@@ -8,7 +8,7 @@ module PostHelper
   # Params:
   # +post_path+::a path to an existing post on the website
   def get_post_submission_url(post_path, ref)
-    return "/post/submit?path=#{post_path}&ref=#{ref}"
+    return "/post/submit?path=#{post_path}&ref=#{ref}" if post_path && ref
     return "/post/submit?path=#{post_path}" if post_path
     return "/post/submit?ref=#{ref}" if ref
     '/post/submit'

--- a/app/helpers/post_helper.rb
+++ b/app/helpers/post_helper.rb
@@ -7,8 +7,10 @@ module PostHelper
   #
   # Params:
   # +post_path+::a path to an existing post on the website
-  def get_post_submission_url(post_path)
+  def get_post_submission_url(post_path, ref)
+    return "/post/submit?path=#{post_path}&ref=#{ref}"
     return "/post/submit?path=#{post_path}" if post_path
+    return "/post/submit?ref=#{ref}" if ref
     '/post/submit'
   end
 

--- a/app/helpers/post_helper.rb
+++ b/app/helpers/post_helper.rb
@@ -7,6 +7,7 @@ module PostHelper
   #
   # Params:
   # +post_path+::a path to an existing post on the website
+  # +ref+::a sha for a ref indicating the head of a branch a post is pushed to on the GitHub server
   def get_post_submission_url(post_path, ref)
     return "/post/submit?path=#{post_path}&ref=#{ref}" if post_path && ref
     return "/post/submit?path=#{post_path}" if post_path

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,5 +1,8 @@
+##
+# An object representing an image that is on a post
 class PostImage
   attr_accessor :filename
+  # The binary contents of an image as a Base64 string
   attr_accessor :contents
 end
 

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -8,4 +8,5 @@ class Post
   attr_accessor :contents
   attr_accessor :tags
   attr_accessor :file_path
+  attr_accessor :images
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,3 +1,8 @@
+class PostImage
+  attr_accessor :filename
+  attr_accessor :contents
+end
+
 ##
 # An object representing a post on the SSE website
 class Post
@@ -12,4 +17,9 @@ class Post
   # The GitHub ref the post's markdown is at. This is used to indicate
   # whether a post is in PR or not
   attr_accessor :github_ref
+  attr_accessor :images
+
+  def initialize
+    @images = []
+  end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -8,5 +8,4 @@ class Post
   attr_accessor :contents
   attr_accessor :tags
   attr_accessor :file_path
-  attr_accessor :images
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -7,5 +7,9 @@ class Post
   attr_accessor :overlay
   attr_accessor :contents
   attr_accessor :tags
+  # Path to the markdown post starting at the root of the repository
   attr_accessor :file_path
+  # The GitHub ref the post's markdown is at. This is used to indicate
+  # whether a post is in PR or not
+  attr_accessor :github_ref
 end

--- a/app/models/post_image_manager.rb
+++ b/app/models/post_image_manager.rb
@@ -32,7 +32,7 @@ class PostImageManager
   # Adds an image that was downloaded from the SSE website repo
   #
   # Params:
-  # +file+:: A PostImage object representing the downloaded image
+  # +downloaded_image+:: A PostImage object representing the downloaded image
   def add_downloaded_image(downloaded_image)
     @downloaded_images << downloaded_image
   end

--- a/app/models/post_image_manager.rb
+++ b/app/models/post_image_manager.rb
@@ -6,12 +6,14 @@ class PostImageManager
   include Singleton
   
   attr_reader :uploaders
+  attr_reader :downloaded_images
 
   ##
   # The constructor for PostImageManager which initializes the array of Carrierware
   # image uploaders to use when submiting a post
   def initialize
     @uploaders = []
+    @downloaded_images = []
   end
 
   ##
@@ -26,6 +28,10 @@ class PostImageManager
     @uploaders << uploader_to_add
   end
 
+  def add_downloaded_image(downloaded_image)
+    @downloaded_images << downloaded_image
+  end
+
   ##
   # Clears the manager of all currently exisiting image uploaders and delete's their cache directories
   def clear
@@ -37,5 +43,6 @@ class PostImageManager
     end
 
     @uploaders.clear
+    @downloaded_images.clear
   end
 end

--- a/app/models/post_image_manager.rb
+++ b/app/models/post_image_manager.rb
@@ -10,7 +10,7 @@ class PostImageManager
 
   ##
   # The constructor for PostImageManager which initializes the array of Carrierware
-  # image uploaders to use when submiting a post
+  # image uploaders to use when submiting a post and the array of downloaded images
   def initialize
     @uploaders = []
     @downloaded_images = []
@@ -28,12 +28,18 @@ class PostImageManager
     @uploaders << uploader_to_add
   end
 
+  ##
+  # Adds an image that was downloaded from the SSE website repo
+  #
+  # Params:
+  # +file+:: A PostImage object representing the downloaded image
   def add_downloaded_image(downloaded_image)
     @downloaded_images << downloaded_image
   end
 
   ##
-  # Clears the manager of all currently exisiting image uploaders and delete's their cache directories
+  # Clears the manager of all currently exisiting image uploaders and delete's their cache directories.
+  # Also clears the manager of all of the downloaded images
   def clear
     @uploaders.each do |uploader| 
       full_preview_path = "#{Rails.root}/public/uploads/tmp/#{uploader.preview.cache_name}"

--- a/app/services/github_service.rb
+++ b/app/services/github_service.rb
@@ -76,8 +76,10 @@ module GithubService
       posts.each do |post|
         oldest_commit = get_oldest_commit_for_file(client, post.path)
         username = client.user[:login]
-        post_api_response = client.contents(full_repo_name, path: post.path)
-        result << create_post_from_api_response(oauth_token, post_api_response) if username == oldest_commit[:author][:login]
+        if username == oldest_commit[:author][:login]
+          post_api_response = client.contents(full_repo_name, path: post.path)
+          result << create_post_from_api_response(oauth_token, post_api_response) 
+        end
       end
       result
     end

--- a/app/services/github_service.rb
+++ b/app/services/github_service.rb
@@ -78,7 +78,7 @@ module GithubService
         username = client.user[:login]
         if username == oldest_commit[:author][:login]
           post_api_response = client.contents(full_repo_name, path: post.path)
-          result << create_post_from_api_response( post_api_response) 
+          result << create_post_from_api_response( post_api_response, nil) 
         end
       end
       result
@@ -104,10 +104,10 @@ module GithubService
             # The CGI.parse method returns a hash with the key being the URL and the value being an array of
             # URI parameters so in order to get the ref we need to grab the first value in the hash and the first
             # URI parameter in the first hash value
-            post = client.contents(full_repo_name, path: pull_request_file[:filename], 
-                                   ref: contents_url_params.values.first.first)
+            ref = contents_url_params.values.first.first
+            post = client.contents(full_repo_name, path: pull_request_file[:filename], ref: ref)
 
-            result << create_post_from_api_response(post)
+            result << create_post_from_api_response(post, ref)
           end
         end
       end
@@ -248,11 +248,11 @@ module GithubService
         commits.find { |x| x[:commit][:committer][:date] == min_date }
       end
 
-      def create_post_from_api_response(post)
+      def create_post_from_api_response(post, ref)
         # Base64.decode64 will convert our string into a ASCII string
         # calling force_encoding('UTF-8') will fix that problem
         text_contents = Base64.decode64(post.content).force_encoding('UTF-8')
-        PostFactory.create_post(text_contents, post.path)
+        PostFactory.create_post(text_contents, post.path, ref)
       end
 
       def get_open_post_editor_pull_requests(oauth_token)

--- a/app/services/github_service.rb
+++ b/app/services/github_service.rb
@@ -140,7 +140,7 @@ module GithubService
     # Params:
     # +oauth_token+::a user's oauth access token
     # +title+:: A title of a SSE website post
-    # +ref+:: The ref indicating which branch the post is on in GitHub
+    # +ref+::a sha for a ref indicating the head of a branch a post is pushed to on the GitHub server
     def get_post_by_title(oauth_token, title, ref)
       result = nil
       result = get_all_posts_in_pr_for_user(oauth_token).find { |x| x.title == title } if ref

--- a/app/services/github_service.rb
+++ b/app/services/github_service.rb
@@ -121,7 +121,9 @@ module GithubService
     # Params:
     # +oauth_token+::a user's oauth access token
     # +title+:: A title of a SSE website post
-    def get_post_by_title(oauth_token, title)
+    # +ref+:: The ref indicating which branch the post is on in GitHub
+    def get_post_by_title(oauth_token, title, ref)
+      return get_all_posts_in_pr_for_user(oauth_token).find { |x| x.title == title} if ref
       get_all_posts(oauth_token).find { |x| x.title == title }
     end
 

--- a/app/services/github_service.rb
+++ b/app/services/github_service.rb
@@ -78,7 +78,7 @@ module GithubService
         username = client.user[:login]
         if username == oldest_commit[:author][:login]
           post_api_response = client.contents(full_repo_name, path: post.path)
-          result << create_post_from_api_response( post_api_response, nil) 
+          result << create_post_from_api_response(post_api_response, nil) 
         end
       end
       result
@@ -123,7 +123,7 @@ module GithubService
     # +title+:: A title of a SSE website post
     # +ref+:: The ref indicating which branch the post is on in GitHub
     def get_post_by_title(oauth_token, title, ref)
-      return get_all_posts_in_pr_for_user(oauth_token).find { |x| x.title == title} if ref
+      return get_all_posts_in_pr_for_user(oauth_token).find { |x| x.title == title } if ref
       get_all_posts(oauth_token).find { |x| x.title == title }
     end
 

--- a/app/services/github_service.rb
+++ b/app/services/github_service.rb
@@ -239,6 +239,19 @@ module GithubService
         client.create_ref(full_repo_name, ref_name, master_head_sha)
     end
 
+    ##
+    # This method will fetch a GitHub's ref name given it's sha identifier.
+    # It will also strip off the starting refs portion of the name
+    #
+    # Params:
+    # +oauth_token+::a user's oauth access token
+    # +ref_sha+:: the sha of the ref to fetch
+    def get_ref_name_by_sha(oauth_token, ref_sha)
+      client = Octokit::Client.new(access_token: oauth_token)
+      ref_response = client.refs(full_repo_name).find { |x| x[:object][:sha] == ref_sha }
+      ref_response[:ref].match(/refs\/(.*)/).captures.first
+    end
+
     private
       def full_repo_name
         "#{Rails.configuration.github_org}/#{Rails.configuration.github_repo_name}"

--- a/app/services/github_service.rb
+++ b/app/services/github_service.rb
@@ -78,7 +78,7 @@ module GithubService
         username = client.user[:login]
         if username == oldest_commit[:author][:login]
           post_api_response = client.contents(full_repo_name, path: post.path)
-          result << create_post_from_api_response(oauth_token, post_api_response) 
+          result << create_post_from_api_response( post_api_response) 
         end
       end
       result
@@ -107,7 +107,7 @@ module GithubService
             post = client.contents(full_repo_name, path: pull_request_file[:filename], 
                                    ref: contents_url_params.values.first.first)
 
-            result << create_post_from_api_response(oauth_token, post)
+            result << create_post_from_api_response(post)
           end
         end
       end
@@ -248,8 +248,7 @@ module GithubService
         commits.find { |x| x[:commit][:committer][:date] == min_date }
       end
 
-      def create_post_from_api_response(oauth_token, post)
-        client = Octokit::Client.new(access_token: oauth_token)
+      def create_post_from_api_response(post)
         # Base64.decode64 will convert our string into a ASCII string
         # calling force_encoding('UTF-8') will fix that problem
         text_contents = Base64.decode64(post.content).force_encoding('UTF-8')
@@ -259,8 +258,8 @@ module GithubService
       def get_open_post_editor_pull_requests(oauth_token)
         client = Octokit::Client.new(access_token: oauth_token)
         open_pull_requests = client.pull_requests(full_repo_name, state: 'open')
-        pull_requests_for_user = open_pull_requests.select { |x| x[:user][:login] == client.user[:login] && 
-                                                                 x[:body] == Rails.configuration.pull_request_body}
+        open_pull_requests.select { |x| x[:user][:login] == client.user[:login] && 
+                                        x[:body] == Rails.configuration.pull_request_body}
       end
   end
 end

--- a/app/services/kramdown_service.rb
+++ b/app/services/kramdown_service.rb
@@ -77,8 +77,14 @@ module KramdownService
 
       get_document_descendants(document.root, document_descendants)
       all_img_tags = document_descendants.select { |x| x.type == :img }
-      
-      all_img_tags.map { |x| x.attr['src'][1..-1] }
+
+      result = all_img_tags.map do | img_tag |
+        if !(img_tag.attr['src'] =~ URI.regexp)
+          img_tag.attr['src'][1..-1]
+        end
+      end
+
+      result.compact
     end
 
     ##

--- a/app/services/kramdown_service.rb
+++ b/app/services/kramdown_service.rb
@@ -21,7 +21,8 @@ module Kramdown::Converter
       if uploader
         el.attr['src'] = "/uploads/tmp/#{uploader.preview.cache_name}" 
       else
-        downloaded_image = PostImageManager.instance.downloaded_images.find { |x| File.basename(x.filename) == File.basename(el.attr['src']) }
+        downloaded_image = PostImageManager.instance.downloaded_images
+                                           .find { |x| File.basename(x.filename) == File.basename(el.attr['src']) }
         if downloaded_image
           extension = File.extname(downloaded_image.filename)
           extension[0] = ''

--- a/app/services/kramdown_service.rb
+++ b/app/services/kramdown_service.rb
@@ -75,7 +75,7 @@ module KramdownService
       lead_break_section = "{: .lead}\r\n<!–-break-–>"
       
       hero_to_use = hero
-      hero_to_use = 'https://source.unsplash.com/collection/145103/' if hero_to_use.empty?
+      hero_to_use = Rails.configuration.default_hero if hero_to_use.empty?
       result = %(---
 layout: post
 title: #{title}

--- a/app/services/kramdown_service.rb
+++ b/app/services/kramdown_service.rb
@@ -67,6 +67,21 @@ module KramdownService
     end
 
     ##
+    # This method returns an array of all image paths given some markdown
+    #
+    # Params:
+    # +markdown+:: text of a markdown post
+    def get_all_image_paths(markdown)
+      document = Kramdown::Document.new(markdown)
+      document_descendants = []
+
+      get_document_descendants(document.root, document_descendants)
+      all_img_tags = document_descendants.select { |x| x.type == :img }
+      
+      all_img_tags.map { |x| x.attr['src'][1..-1] }
+    end
+
+    ##
     # This method takes parameters for a given post and formats them
     # as a valid jekyll post for the SSE website
     #

--- a/app/services/kramdown_service.rb
+++ b/app/services/kramdown_service.rb
@@ -16,7 +16,17 @@ module Kramdown::Converter
     def convert_img(el, _indent)
       formatted_filename = File.basename(el.attr['src']).tr(' ', '_') 
       uploader = PostImageManager.instance.uploaders.find { |x| x.filename == formatted_filename }
-      el.attr['src'] = "/uploads/tmp/#{uploader.preview.cache_name}" if uploader
+      if uploader
+        el.attr['src'] = "/uploads/tmp/#{uploader.preview.cache_name}" 
+      else
+        downloaded_image = PostImageManager.instance.downloaded_images.find { |x| File.basename(x.filename) == File.basename(el.attr['src']) }
+        if downloaded_image
+          extension = File.extname(downloaded_image.filename)
+          extension[0] = ''
+          el.attr['src'] = "data:image/#{extension};base64,#{downloaded_image.contents}"
+        end
+      end
+      
       super(el, _indent)
     end
   end

--- a/app/services/kramdown_service.rb
+++ b/app/services/kramdown_service.rb
@@ -8,7 +8,9 @@ module Kramdown::Converter
   class Preview < Html
     ##
     # An override of the convert_img tag which converts all image sources to pull
-    # from the CarrierWare cache location if an uploader exists with the image's filename
+    # from the CarrierWare cache location if an uploader exists with the image's filename. 
+    # Or the Base64 contents of a downloaded image are replaced in the src attribute if the image
+    # was downloaded for the post
     #
     # Params:
     # +el+::the image element to convert to html

--- a/app/services/post_service.rb
+++ b/app/services/post_service.rb
@@ -73,6 +73,27 @@ module PostService
     end
 
     ##
+    # This method submits changes to a post that is already in PR, commiting and pushing the markdown changes
+    # and any added photos to the branch. Since the post is in PR these changes will be a PR updated to the given branch
+    #
+    # Params:
+    # +oauth_token+::a user's oauth access token
+    # +post_markdown+::the modified markdown to submit
+    # +post_title+::the title for the existing post
+    # +existing_post_file_path+::the file path to the existing post on GitHub
+    # +ref+::the ref to update
+    def edit_post_in_pr(oauth_token, post_markdown, post_title, existing_post_file_path, ref)
+      ref_name = GithubService.get_ref_name_by_sha(oauth_token, ref)
+      sha_base_tree = GithubService.get_base_tree_for_branch(oauth_token, ref)
+
+      new_tree_sha = create_new_tree(oauth_token, post_markdown, post_title, existing_post_file_path, sha_base_tree)
+      GithubService.commit_and_push_to_repo(oauth_token, "Edited post #{post_title}",
+                                            new_tree_sha, ref, ref_name)
+      
+      PostImageManager.instance.clear
+    end
+
+    ##
     # This method validates the hero for a post when the hero is a URL. In that case we make a request to the URL
     # to see if the URL is an image or not. The URL must be an image in order for the URL to be valid
     #

--- a/app/services/post_service.rb
+++ b/app/services/post_service.rb
@@ -66,7 +66,8 @@ module PostService
       GithubService.commit_and_push_to_repo(oauth_token, "Edited post #{post_title}", 
                                             new_tree_sha, master_head_sha, ref_name)
       GithubService.create_pull_request(oauth_token, branch_name, 'master', "Edited Post #{post_title}", 
-                                        PULL_REQUEST_BODY, [Rails.configuration.webmaster_github_username])
+                                        Rails.configuration.pull_request_body, 
+                                        [Rails.configuration.webmaster_github_username])
       
       PostImageManager.instance.clear
     end

--- a/app/views/post/edit.html.erb
+++ b/app/views/post/edit.html.erb
@@ -1,5 +1,5 @@
 <%= javascript_include_tag 'postEdit', 'data-turbolinks-track': 'reload' %>
-<%= form_tag(get_post_submission_url(@post.file_path), method: 'post') do %>
+<%= form_tag(get_post_submission_url(@post.file_path, @post.github_ref), method: 'post') do %>
   <%= content_tag(:div, class: 'editContainer') do %>
     <%= content_tag(:div, class: 'editMiddleContainer') do %>
       <%= render template: 'shared/header' %>

--- a/app/views/post/edit.html.erb
+++ b/app/views/post/edit.html.erb
@@ -8,11 +8,6 @@
           <%= content_tag(:strong, flash[:alert]) %>
         <% end %>
       <% end %>
-      <% if flash[:notice] %>
-        <%= content_tag :div, class: 'alert alert-success', role: 'alert' do %>
-          <%= content_tag(:strong, flash[:notice]) %>
-        <% end %>
-      <% end %>
       <%= content_tag(:div, class: 'editHeaderContainer') do %>
         <%= content_tag(:div, class: 'form-group') do %>
           <%= label_tag('Title:')%>

--- a/app/views/post/list.html.erb
+++ b/app/views/post/list.html.erb
@@ -1,6 +1,12 @@
+<%= javascript_include_tag 'postList', 'data-turbolinks-track': 'reload' %>
 <%= content_tag(:div, class: 'listContainer') do %>
   <%= content_tag(:div, class: 'listMiddleContainer') do %>
     <%= render template: 'shared/header' %>
+    <% if flash[:notice] %>
+      <%= content_tag :div, class: 'alert alert-success', role: 'alert' do %>
+        <%= content_tag(:strong, flash[:notice]) %>
+      <% end %>
+    <% end %>
     <%= content_tag(:div, class: 'listHeaderContainer') do %>
       <%= content_tag(:span) do %>
         <%= content_tag(:h1, 'Post List') %>

--- a/app/views/post/list.html.erb
+++ b/app/views/post/list.html.erb
@@ -21,7 +21,7 @@
       <%= content_tag(:h3, 'Posts in Review') %>
       <%= content_tag(:ul, class: 'prPostList') do %>
         <% @pr_posts.each do |post| %>
-          <% concat(content_tag(:li, link_to(post.title, { controller: 'post', action: 'edit', title: post.title}) )) %>
+          <% concat(content_tag(:li, link_to(post.title, { controller: 'post', action: 'edit', title: post.title, ref: post.github_ref}) )) %>
         <% end %>
       <% end %>
     <% end %>

--- a/app/views/post/list.html.erb
+++ b/app/views/post/list.html.erb
@@ -7,20 +7,22 @@
         <%= link_to('Create Post', { controller: 'post', action: 'edit'}, class: 'btn btn-primary active createPostLink') %>
       <% end %>
     <% end %>
+    <% if @posts.length == 0 && @pr_posts.length == 0 %>
+      <%= content_tag(:div, 'No previously created posts.', class: 'noPostsMessage') %>
+    <% end %>
+
     <%= content_tag(:ul, class: 'postList') do %>
       <% @posts.each do |post| %>
         <% concat(content_tag(:li, link_to(post.title, { controller: 'post', action: 'edit', title: post.title }) )) %>
       <% end %>
-      
-      <% if @pr_posts.length > 0 %>
-        <%= content_tag(:h1, 'Posts in Review') %>
+    <% end %>
+    
+    <% if @pr_posts.length > 0 %>
+      <%= content_tag(:h3, 'Posts in Review') %>
+      <%= content_tag(:ul, class: 'prPostList') do %>
         <% @pr_posts.each do |post| %>
           <% concat(content_tag(:li, link_to(post.title, { controller: 'post', action: 'edit', title: post.title}) )) %>
         <% end %>
-      <% end %>
-
-      <% if @posts.length == 0 && @pr_posts.length == 0 %>
-        <%= content_tag(:div, 'No previously created posts.', class: 'noPostsMessage') %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/post/list.html.erb
+++ b/app/views/post/list.html.erb
@@ -8,11 +8,18 @@
       <% end %>
     <% end %>
     <%= content_tag(:ul, class: 'postList') do %>
-      <% if @posts.length > 0 %>
-        <% @posts.each do |post| %>
-          <% concat(content_tag(:li, link_to(post.title, { controller: 'post', action: 'edit', title: post.title }) )) %>
+      <% @posts.each do |post| %>
+        <% concat(content_tag(:li, link_to(post.title, { controller: 'post', action: 'edit', title: post.title }) )) %>
+      <% end %>
+      
+      <% if @pr_posts.length > 0 %>
+        <%= content_tag(:h1, 'Posts in Review') %>
+        <% @pr_posts.each do |post| %>
+          <% concat(content_tag(:li, link_to(post.title, { controller: 'post', action: 'edit', title: post.title}) )) %>
         <% end %>
-      <% else %>
+      <% end %>
+
+      <% if @posts.length == 0 && @pr_posts.length == 0 %>
         <%= content_tag(:div, 'No previously created posts.', class: 'noPostsMessage') %>
       <% end %>
     <% end %>

--- a/app/views/shared/header.html.erb
+++ b/app/views/shared/header.html.erb
@@ -1,4 +1,4 @@
 <%= content_tag(:span, class: 'logoContainer') do %>
-  <%= image_tag('logo.svg') %>
+  <%= link_to(image_tag('logo.svg'), { controller: 'post', action: 'list' }) %>
   <%= content_tag(:h1, 'SSE Website Post Editor') %>
 <% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -22,5 +22,6 @@ module JekyllPostEditor
     # the framework and any gems in your application.
     config.github_org = 'msoe-sse'
     config.webmaster_github_username = 'msoe-sse-webmaster'
+    config.pull_request_body = 'This pull request was opened automatically by the jekyll-post-editor.'
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,5 +23,6 @@ module JekyllPostEditor
     config.github_org = 'msoe-sse'
     config.webmaster_github_username = 'msoe-sse-webmaster'
     config.pull_request_body = 'This pull request was opened automatically by the jekyll-post-editor.'
+    config.default_hero = 'https://source.unsplash.com/collection/145103/'
   end
 end

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -13,3 +13,4 @@ Rails.application.config.assets.paths << Rails.root.join('node_modules')
 # folder are already added.
 # Rails.application.config.assets.precompile += %w( admin.js admin.css )
 Rails.application.config.assets.precompile += %w( postEdit.js )
+Rails.application.config.assets.precompile += %w( postList.js )

--- a/test/factories/post_factory_test.rb
+++ b/test/factories/post_factory_test.rb
@@ -45,7 +45,7 @@ overlay: green
     assert_equal 'Some Post', result.title
     assert_equal 'Andrew Wojciechowski', result.author
     assert_equal 'announcement, info', result.tags
-    assert_equal 'https://source.unsplash.com/collection/145103/', result.hero
+    assert_equal '', result.hero
     assert_equal 'green', result.overlay
     assert_equal "#An H1 tag\n##An H2 tag", result.contents
   end
@@ -59,7 +59,7 @@ author: Andrew Wojciechowski\r
 tags:\r
   - announcement\r
   - info\r
-hero: https://source.unsplash.com/collection/145103/\r
+hero: https://source.unsplash.com/collection/145103/blah.com\r
 overlay: green\r
 ---\r
 #{LEAD_BREAK_SECTION2}
@@ -75,7 +75,7 @@ overlay: green\r
     assert_equal "Some Post\r", result.title
     assert_equal "Andrew Wojciechowski\r", result.author
     assert_equal "announcement\r, info\r", result.tags
-    assert_equal "https://source.unsplash.com/collection/145103/\r", result.hero
+    assert_equal "https://source.unsplash.com/collection/145103/blah.com\r", result.hero
     assert_equal "green\r", result.overlay
     assert_equal "#An H1 tag\r\n##An H2 tag", result.contents
   end

--- a/test/factories/post_factory_test.rb
+++ b/test/factories/post_factory_test.rb
@@ -6,7 +6,7 @@ class PostFactoryTest < ActiveSupport::TestCase
 
   test 'create_post should return nil if given a nil value for post_contents' do 
     # Act
-    result = PostFactory.create_post(nil, nil)
+    result = PostFactory.create_post(nil, nil, nil)
 
     # Assert
     assert_nil result
@@ -14,7 +14,7 @@ class PostFactoryTest < ActiveSupport::TestCase
 
   test 'create_post should return nil if given a non-string type for post_contents' do
     # Act
-    result = PostFactory.create_post(1, 'my post.md')
+    result = PostFactory.create_post(1, 'my post.md', 'myref')
 
     # Assert
     assert_nil result
@@ -37,10 +37,11 @@ overlay: green
 ##An H2 tag)
 
     # Act
-    result = PostFactory.create_post(post_contents, 'my post.md')
+    result = PostFactory.create_post(post_contents, 'my post.md', 'myref')
 
     # Assert
     assert_equal 'my post.md', result.file_path
+    assert_equal 'myref', result.github_ref
     assert_equal 'Some Post', result.title
     assert_equal 'Andrew Wojciechowski', result.author
     assert_equal 'announcement, info', result.tags
@@ -66,10 +67,11 @@ overlay: green\r
 ##An H2 tag)
         
     # Act
-    result = PostFactory.create_post(post_contents, 'my post.md')
+    result = PostFactory.create_post(post_contents, 'my post.md', 'myref')
         
     # Assert
     assert_equal 'my post.md', result.file_path
+    assert_equal 'myref', result.github_ref
     assert_equal "Some Post\r", result.title
     assert_equal "Andrew Wojciechowski\r", result.author
     assert_equal "announcement\r, info\r", result.tags

--- a/test/helpers/post_helper_test.rb
+++ b/test/helpers/post_helper_test.rb
@@ -3,24 +3,40 @@ require 'test_helper'
 class PostHelperTest < ActiveSupport::TestCase
   include PostHelper
 
-  test 'get_post_submission_url should not add a path url parameter given a nil path' do 
+  test 'get_post_submission_url should not add any parameters given a nil path and ref' do 
     # Act
-    result = get_post_submission_url(nil)
+    result = get_post_submission_url(nil, nil)
 
     # Assert
     assert_equal '/post/submit', result
   end
 
   test 'get_post_submission_url should add a path url parameter given a path as a string' do 
-    # Arrange
-    result = get_post_submission_url('my-path')
+    # Act
+    result = get_post_submission_url('my-path', nil)
 
     # Assert
     assert_equal '/post/submit?path=my-path', result
   end
 
+  test 'get_post_submission_url should add a ref url parameter given a ref as a string' do 
+    # Act
+    result = get_post_submission_url(nil, 'my-ref')
+
+    # Assert
+    assert_equal '/post/submit?ref=my-ref', result
+  end
+
+  test 'get_post_submission_url should add a path and ref url parameter given both values as a string' do 
+    # Act
+    result = get_post_submission_url('my-path', 'my-ref')
+
+    # Assert
+    assert_equal '/post/submit?path=my-path&ref=my-ref', result
+  end
+
   test 'get_selected_overlay should return Red if the overlay passed in matches red in any case' do 
-    # Arrange
+    # Act
     result = get_selected_overlay('REd')
 
     # Assert
@@ -28,7 +44,7 @@ class PostHelperTest < ActiveSupport::TestCase
   end
 
   test 'get_selected_overlay should return Blue if the overlay passed in matches blue in any case' do 
-    # Arrange
+    # Act
     result = get_selected_overlay('BLUe')
 
     # Assert
@@ -36,7 +52,7 @@ class PostHelperTest < ActiveSupport::TestCase
   end
 
   test 'get_selected_overlay should return Green if the overlay passed in matches green in any case' do 
-    # Arrange
+    # Act
     result = get_selected_overlay('GREen')
 
     # Assert
@@ -44,7 +60,7 @@ class PostHelperTest < ActiveSupport::TestCase
   end
 
   test 'get_selected_overlay should return nil if the overlay does not match red, blue, or green' do 
-    # Arrange
+    # Act
     result = get_selected_overlay('Aqua Marine')
 
     # Assert

--- a/test/integration/post_controller_test.rb
+++ b/test/integration/post_controller_test.rb
@@ -285,13 +285,13 @@ class PostControllerTest < BaseIntegrationTest
                                     hero: 'https://source.unsplash.com/collection/145103/' }
             
     # Assert
-    assert_redirected_to '/post/edit'
+    assert_redirected_to '/post/list'
     assert_nil flash[:alert]
     assert_equal 'Post Successfully Submited', flash[:notice]
   end
 
   test 'post/submit?path should submit the existing post to GitHub 
-        and redirect back to the edit screen with a valid post' do 
+        and redirect back to the list screen with a valid post' do 
     # Arrange
     setup_session('access token', true)
     GithubService.expects(:check_sse_github_org_membership).with('access token').returns(true)
@@ -305,13 +305,13 @@ class PostControllerTest < BaseIntegrationTest
                                                 markdownArea: '# hello', tags: 'tags', overlay: 'red', hero: '' }
 
     # Assert
-    assert_redirected_to '/post/edit'
+    assert_redirected_to '/post/list'
     assert_nil flash[:alert]
     assert_equal 'Post Successfully Submited', flash[:notice]
   end
 
   test 'post/submit?path&ref should submit the existing post to GitHub
-        and redirect back to the edit screen with a valid post' do 
+        and redirect back to the list screen with a valid post' do 
     # Arrange
     setup_session('access token', true)
     GithubService.expects(:check_sse_github_org_membership).with('access token').returns(true)
@@ -326,7 +326,7 @@ class PostControllerTest < BaseIntegrationTest
                                                         overlay: 'red', hero: '' }
     
     # Assert
-    assert_redirected_to '/post/edit'
+    assert_redirected_to '/post/list'
     assert_nil flash[:alert]
     assert_equal 'Post Successfully Submited', flash[:notice]
   end

--- a/test/integration/post_controller_test.rb
+++ b/test/integration/post_controller_test.rb
@@ -8,7 +8,10 @@ class PostControllerTest < BaseIntegrationTest
                               overlay: 'overlay1', contents: 'contents1', tags: ['tag1', 'tag2'])
     post2 = create_post_model(title: 'title2', author: 'author2', hero: 'hero2', 
                               overlay: 'overlay2', contents: 'contents2', tags: ['tag1', 'tag2'])
+    pr_post = create_post_model(title: 'pr post', author: 'pr author', hero: 'pr hero',
+                                overlay: 'pr overlay', contents: 'pr contents', tags: ['tag1', 'tag2'])
     GithubService.expects(:get_all_posts).with('access token').returns([post1, post2])
+    GithubService.expects(:get_all_posts_in_pr_for_user).with('access token').returns([pr_post])
 
     # Act
     get '/post/list'
@@ -26,7 +29,10 @@ class PostControllerTest < BaseIntegrationTest
                               overlay: 'overlay1', contents: 'contents1', tags: ['tag1', 'tag2'])
     post2 = create_post_model(title: 'title2', author: 'author2', hero: 'hero2', 
                               overlay: 'overlay2', contents: 'contents2', tags: ['tag1', 'tag2'])
+    pr_post = create_post_model(title: 'pr post', author: 'pr author', hero: 'pr hero',
+                                overlay: 'pr overlay', contents: 'pr contents', tags: ['tag1', 'tag2'])
     GithubService.expects(:get_all_posts).with('access token').returns([post1, post2])
+    GithubService.expects(:get_all_posts_in_pr_for_user).with('access token').returns([pr_post])
 
     # Act
     get '/'

--- a/test/integration/post_controller_test.rb
+++ b/test/integration/post_controller_test.rb
@@ -268,7 +268,7 @@ class PostControllerTest < BaseIntegrationTest
  end
   
 
-  test 'post/submit should submit the new post to GitHub and redirect back to the edit screen with a valid post' do 
+  test 'post/submit should submit the new post to GitHub and redirect back to the list screen with a valid post' do 
     # Arrange
     setup_session('access token', true)
     GithubService.expects(:check_sse_github_org_membership).with('access token').returns(true)
@@ -290,7 +290,7 @@ class PostControllerTest < BaseIntegrationTest
     assert_equal 'Post Successfully Submited', flash[:notice]
   end
 
-  test 'post/submit? should submit the existing post to GitHub 
+  test 'post/submit?path should submit the existing post to GitHub 
         and redirect back to the edit screen with a valid post' do 
     # Arrange
     setup_session('access token', true)
@@ -304,6 +304,26 @@ class PostControllerTest < BaseIntegrationTest
     post '/post/submit?path=path.md', params: { title: 'title', author: 'author', 
                                                 markdownArea: '# hello', tags: 'tags', overlay: 'red', hero: '' }
 
+    # Assert
+    assert_redirected_to '/post/edit'
+    assert_nil flash[:alert]
+    assert_equal 'Post Successfully Submited', flash[:notice]
+  end
+
+  test 'post/submit?path&ref should submit the existing post to GitHub
+        and redirect back to the edit screen with a valid post' do 
+    # Arrange
+    setup_session('access token', true)
+    GithubService.expects(:check_sse_github_org_membership).with('access token').returns(true)
+
+    PostService.expects(:edit_post_in_pr).with('access token', 'post text', 'title', 'path.md', 'ref').once
+    KramdownService.expects(:create_jekyll_post_text)
+                   .with('# hello', 'author', 'title', 'tags', 'red', '').returns('post text')
+
+    # Act
+    post '/post/submit?path=path.md&ref=ref', params: { title: 'title', author: 'author', 
+                                                        markdownArea: '# hello', tags: 'tags', overlay: 'red', hero: '' }
+    
     # Assert
     assert_redirected_to '/post/edit'
     assert_nil flash[:alert]

--- a/test/integration/post_controller_test.rb
+++ b/test/integration/post_controller_test.rb
@@ -322,7 +322,8 @@ class PostControllerTest < BaseIntegrationTest
 
     # Act
     post '/post/submit?path=path.md&ref=ref', params: { title: 'title', author: 'author', 
-                                                        markdownArea: '# hello', tags: 'tags', overlay: 'red', hero: '' }
+                                                        markdownArea: '# hello', tags: 'tags', 
+                                                        overlay: 'red', hero: '' }
     
     # Assert
     assert_redirected_to '/post/edit'

--- a/test/integration/post_controller_test.rb
+++ b/test/integration/post_controller_test.rb
@@ -119,13 +119,28 @@ class PostControllerTest < BaseIntegrationTest
 
     post = create_post_model(title: 'title', author: 'author', hero: 'hero', 
                               overlay: 'overlay', contents: 'contents',  tags: ['tag1', 'tag2'])
-    GithubService.expects(:get_post_by_title).with('access token', 'title').returns(post)
+    GithubService.expects(:get_post_by_title).with('access token', 'title', nil).returns(post)
 
     # Act
     get '/post/edit?title=title'
 
     # Assert
     assert_response :success
+  end
+
+  test 'an authenticated user should be able to navigate to post/edit successfully with a title and ref parameter' do 
+    # Arrange
+    setup_session('access token', true)
+    GithubService.expects(:check_sse_github_org_membership).with('access token').returns(true)
+
+    post = create_post_model(title: 'title', author: 'author', hero: 'hero', 
+                              overlay: 'overlay', contents: 'contents',  tags: ['tag1', 'tag2'])
+    GithubService.expects(:get_post_by_title).with('access token', 'title', 'ref').returns(post)
+
+    # Act
+    get '/post/edit?title=title&ref=ref'
+
+    # ASsert
   end
 
   test 'post/edit should create a post from the session if session[:post_stored] is true' do 

--- a/test/models/post_image_manager_test.rb
+++ b/test/models/post_image_manager_test.rb
@@ -35,6 +35,20 @@ class PostImageManagerTest < ActiveSupport::TestCase
     assert PostImageManager.instance.uploaders.first.is_a?(PostImageUploader)
   end
 
+  test 'add_downloaded_image should add a downloaded image to the donwloaded_images collection' do 
+    # Arrange
+    post_image = PostImage.new
+    post_image.filename = 'Sample.jpg'
+    post_image.contents = 'contents'
+
+    # Act
+    PostImageManager.instance.add_downloaded_image(post_image)
+
+    # Assert
+    assert_equal 1, PostImageManager.instance.downloaded_images.length
+    assert PostImageManager.instance.downloaded_images.first.is_a?(PostImage)
+  end
+
   test 'clear should clear all PostImageUploader instances from the manager' do 
     # Arrange
     mock_file = create_mock_action_dispatch_file('my file.jpg')
@@ -47,6 +61,20 @@ class PostImageManagerTest < ActiveSupport::TestCase
 
     # Assert
     assert_equal 0, PostImageManager.instance.uploaders.length
+  end
+
+  test 'clear should clear all PostImage instances from the manager' do 
+    # Arrange
+    post_image = PostImage.new
+    post_image.filename = 'Sample.jpg'
+    post_image.contents = 'contents'
+    
+    # Act
+    PostImageManager.instance.add_downloaded_image(post_image)
+    PostImageManager.instance.clear
+
+    # Assert
+    assert_equal 0, PostImageManager.instance.downloaded_images.length
   end
 
   private

--- a/test/services/github_service_test.rb
+++ b/test/services/github_service_test.rb
@@ -189,7 +189,7 @@ class GithubServiceTest < ActiveSupport::TestCase
     GithubService.expects(:get_all_posts).with('my token').returns([post1_model, post2_model, post3_model])
 
     # Act
-    result = GithubService.get_post_by_title('my token', 'a very fake post')
+    result = GithubService.get_post_by_title('my token', 'a very fake post', nil)
 
     # Assert
     assert_nil result
@@ -207,7 +207,43 @@ class GithubServiceTest < ActiveSupport::TestCase
     GithubService.expects(:get_all_posts).with('my token').returns([post1_model, post2_model, post3_model])
 
     # Act
-    result = GithubService.get_post_by_title('my token', 'post 2')
+    result = GithubService.get_post_by_title('my token', 'post 2', nil)
+
+    # Assert
+    assert_equal post2_model, result
+  end
+
+  test 'get_post_by_title should return nil if the post does not exist on a given ref' do 
+    # Arrange
+    post1_model = create_post_model(title: 'post 1', author: 'Andy Wojciechowski', hero: 'hero 1',
+                                    overlay: 'overlay 1', contents: '#post1', tags: ['announcement', 'info'])
+    post2_model = create_post_model(title: 'post 2', author: 'Grace Fleming', hero: 'hero 2',
+                                    overlay: 'overlay 2', contents: '##post2', tags: ['announcement'])
+    post3_model = create_post_model(title: 'post 3', author: 'Sabrina Stangler', hero: 'hero 3',
+                                    overlay: 'overlay 3', contents: '###post3', tags: ['info'])
+
+    GithubService.expects(:get_all_posts_in_pr_for_user).with('my token').returns([post1_model, post2_model, post3_model])
+
+    # Act
+    result = GithubService.get_post_by_title('my token', 'a very fake post', 'ref')
+
+    # Assert
+    assert_nil result
+  end
+
+  test 'get_post_by_title should return a given post by its title given a ref' do 
+    # Arrange
+    post1_model = create_post_model(title: 'post 1', author: 'Andy Wojciechowski', hero: 'hero 1',
+                                    overlay: 'overlay 1', contents: '#post1', tags: ['announcement', 'info'])
+    post2_model = create_post_model(title: 'post 2', author: 'Grace Fleming', hero: 'hero 2',
+                                    overlay: 'overlay 2', contents: '##post2', tags: ['announcement'])
+    post3_model = create_post_model(title: 'post 3', author: 'Sabrina Stangler', hero: 'hero 3',
+                                    overlay: 'overlay 3', contents: '###post3', tags: ['info'])
+
+    GithubService.expects(:get_all_posts_in_pr_for_user).with('my token').returns([post1_model, post2_model, post3_model])
+
+    # Act
+    result = GithubService.get_post_by_title('my token', 'post 2', 'ref')
 
     # Assert
     assert_equal post2_model, result

--- a/test/services/github_service_test.rb
+++ b/test/services/github_service_test.rb
@@ -128,9 +128,9 @@ class GithubServiceTest < ActiveSupport::TestCase
     Base64.expects(:decode64).with('post 2 base 64 content').returns('post 2 text content').never
     Base64.expects(:decode64).with('post 3 base 64 content').returns('post 3 text content')
     
-    PostFactory.expects(:create_post).with('post 1 text content', '_posts/post1.md').returns(post1_model)
-    PostFactory.expects(:create_post).with('post 2 text content', '_posts/post2.md').returns(post2_model).never
-    PostFactory.expects(:create_post).with('post 3 text content', '_posts/post3.md').returns(post3_model)
+    PostFactory.expects(:create_post).with('post 1 text content', '_posts/post1.md', nil).returns(post1_model)
+    PostFactory.expects(:create_post).with('post 2 text content', '_posts/post2.md', nil).returns(post2_model).never
+    PostFactory.expects(:create_post).with('post 3 text content', '_posts/post3.md', nil).returns(post3_model)
 
     # Act
     result = GithubService.get_all_posts('my token')
@@ -168,7 +168,7 @@ class GithubServiceTest < ActiveSupport::TestCase
                    .returns(post_content)
     
     Base64.expects(:decode64).with('PR base 64 content').returns('PR content')
-    PostFactory.expects(:create_post).with('PR content', 'sample.md').returns(post_model)
+    PostFactory.expects(:create_post).with('PR content', 'sample.md', 'myref').returns(post_model)
 
     # Act
     result = GithubService.get_all_posts_in_pr_for_user('my token')

--- a/test/services/github_service_test.rb
+++ b/test/services/github_service_test.rb
@@ -384,6 +384,38 @@ class GithubServiceTest < ActiveSupport::TestCase
     
     # No Assert - taken care of with mocha mock setups
   end
+
+  test 'get_ref_name_by_sha should return the properly formatted ref name from Octokit' do 
+    # Arrange
+    response = [
+      {
+        ref: 'refs/heads/branch1',
+        object: {
+          sha: 'sha 1'
+        }
+      },
+      {
+        ref: 'refs/heads/branch2',
+        object: {
+          sha: 'sha 2'
+        }
+      },
+      {
+        ref: 'refs/heads/branch3',
+        object: {
+          sha: 'sha 3'
+        }
+      }
+    ]
+
+    Octokit::Client.any_instance.expects(:refs).with('msoe-sse/jekyll-post-editor-test-repo').returns(response)
+
+    # Act
+    result = GithubService.get_ref_name_by_sha('my token', 'sha 2')
+
+    # Assert
+    assert_equal 'heads/branch2', result
+  end
   
   private
     def create_dummy_api_resource(parameters)

--- a/test/services/github_service_test.rb
+++ b/test/services/github_service_test.rb
@@ -222,7 +222,8 @@ class GithubServiceTest < ActiveSupport::TestCase
     post3_model = create_post_model(title: 'post 3', author: 'Sabrina Stangler', hero: 'hero 3',
                                     overlay: 'overlay 3', contents: '###post3', tags: ['info'])
 
-    GithubService.expects(:get_all_posts_in_pr_for_user).with('my token').returns([post1_model, post2_model, post3_model])
+    GithubService.expects(:get_all_posts_in_pr_for_user)
+                 .with('my token').returns([post1_model, post2_model, post3_model])
 
     # Act
     result = GithubService.get_post_by_title('my token', 'a very fake post', 'ref')
@@ -240,7 +241,8 @@ class GithubServiceTest < ActiveSupport::TestCase
     post3_model = create_post_model(title: 'post 3', author: 'Sabrina Stangler', hero: 'hero 3',
                                     overlay: 'overlay 3', contents: '###post3', tags: ['info'])
 
-    GithubService.expects(:get_all_posts_in_pr_for_user).with('my token').returns([post1_model, post2_model, post3_model])
+    GithubService.expects(:get_all_posts_in_pr_for_user)
+                 .with('my token').returns([post1_model, post2_model, post3_model])
 
     # Act
     result = GithubService.get_post_by_title('my token', 'post 2', 'ref')

--- a/test/services/github_service_test.rb
+++ b/test/services/github_service_test.rb
@@ -138,6 +138,22 @@ class GithubServiceTest < ActiveSupport::TestCase
     # Assert
     assert_equal [post1_model, post3_model], result
   end
+
+  test 'get_all_posts_in_pr_for_user should return all posts in PR for a user' do 
+    # Arrange
+    Octokit::Client.any_instance(:user).returns({login: 'andy-wojciechowski'})
+
+    Octokit::Client.any_instance(:pull_requests).with('msoe-sse/jekyll-post-editor-test-repo', state: 'open')
+                   .returns([create_pull_request_hash('msoe-sse-webmaster', 
+                            'This pull request was opened automatically by the jekyll-post-editor.'),
+                            create_pull_request_hash('andy-wojciechowski', 'My Pull Request Body'),
+                            create_pull_request_hash('andy-wojciechowski', 
+                            'This pull request was opened automatically by the jekyll-post-editor.')])
+    # Act
+    result = GithubService.get_all_posts_in_pr_for_user('my token')
+
+    # Assert
+  end
   
   test 'get_post_by_title should return nil if the post does not exist' do
     # Arrange
@@ -349,6 +365,15 @@ class GithubServiceTest < ActiveSupport::TestCase
         author: {
           login: login
         }
+      }
+    end
+
+    def create_pull_request_hash(username, body)
+      {
+        user: {
+          login: username
+        },
+        body: body
       }
     end
 

--- a/test/services/github_service_test.rb
+++ b/test/services/github_service_test.rb
@@ -142,6 +142,7 @@ class GithubServiceTest < ActiveSupport::TestCase
   test 'get_all_posts_in_pr_for_user should return all posts in PR for a user' do 
     # Arrange
     post_content = create_dummy_api_resource(content: 'PR base 64 content', path: 'sample.md')
+    image_content = create_dummy_api_resource(content: 'imagecontents', path: 'sample.jpeg')
     post_model = create_post_model(title: 'post', author: 'Andy Wojciechowski', hero: 'hero',
                                    overlay: 'overlay', contents: '#post', tags: ['announcement', 'info'])
 
@@ -166,6 +167,10 @@ class GithubServiceTest < ActiveSupport::TestCase
     Octokit::Client.any_instance.expects(:contents)
                    .with('msoe-sse/jekyll-post-editor-test-repo', path: 'sample.md', ref: 'myref')
                    .returns(post_content)
+
+    Octokit::Client.any_instance.expects(:contents)
+                   .with('msoe-sse/jekyll-post-editor-test-repo', path: 'sample.jpeg', ref: 'myref')
+                   .returns(image_content) 
     
     Base64.expects(:decode64).with('PR base 64 content').returns('PR content')
     PostFactory.expects(:create_post).with('PR content', 'sample.md', 'myref').returns(post_model)
@@ -175,6 +180,10 @@ class GithubServiceTest < ActiveSupport::TestCase
 
     # Assert
     assert_equal [post_model], result
+
+    assert_not_nil post_model.images
+    assert_equal 'sample.jpeg', post_model.images.first.filename
+    assert_equal 'imagecontents', post_model.images.first.contents
   end
   
   test 'get_post_by_title should return nil if the post does not exist' do

--- a/test/services/kramdown_service_test.rb
+++ b/test/services/kramdown_service_test.rb
@@ -126,6 +126,19 @@ Andy is nice)
     assert_equal 'My File.jpg', result
   end
 
+  test 'get_all_image_paths should return all image paths given some markdown' do 
+    # Arrange
+    markdown = "![My Alt Text](/assets/img/My File.jpg)\r\n![My Alt Text](/assets/img/My File2.jpg)"
+
+    # Act
+    result = KramdownService.get_all_image_paths(markdown)
+
+    # Assert
+    assert_equal 2, result.length
+    assert_equal 'assets/img/My File.jpg', result[0]
+    assert_equal 'assets/img/My File2.jpg', result[1]
+  end
+
   test 'create_jekyll_post_text should return text for a formatted post' do 
     # Arrange
     expected_post = %(---

--- a/test/services/kramdown_service_test.rb
+++ b/test/services/kramdown_service_test.rb
@@ -16,7 +16,8 @@ Andy is nice)
     assert_not_nil result
   end
   
-  test 'get_preview should not update the src atribute of image tags if no uploader or PostImage exists in PostImageManager' do 
+  test 'get_preview should not update the src atribute of image tags 
+        if no uploader or PostImage exists in PostImageManager' do 
     # Arrange
     mock_uploader = create_mock_uploader('preview_no image.png', 'my cache', nil)
     preview_uploader = create_preview_uploader('no image.png', mock_uploader)

--- a/test/services/kramdown_service_test.rb
+++ b/test/services/kramdown_service_test.rb
@@ -16,12 +16,14 @@ Andy is nice)
     assert_not_nil result
   end
   
-  test 'get_preview should not update the src atribute of image tags if no uploader exists in PostImageManager' do 
+  test 'get_preview should not update the src atribute of image tags if no uploader or PostImage exists in PostImageManager' do 
     # Arrange
     mock_uploader = create_mock_uploader('preview_no image.png', 'my cache', nil)
     preview_uploader = create_preview_uploader('no image.png', mock_uploader)
+    post_image = create_post_image('no image2.png', 'contents')
 
     PostImageManager.instance.expects(:uploaders).returns([ preview_uploader ])
+    PostImageManager.instance.expects(:downloaded_images).returns([ post_image ])
 
     markdown = '![20170610130401_1.jpg](/assets/img/20170610130401_1.jpg)'
 
@@ -36,11 +38,29 @@ Andy is nice)
     # Arrange
     mock_uploader = create_mock_uploader('preview_20170610130401_1.jpg', 'my cache/preview_20170610130401_1.jpg', nil)
     preview_uploader = create_preview_uploader('20170610130401_1.jpg', mock_uploader)
+    post_image = create_post_image('assets/img/20170610130401_1.jpg', 'contents')
 
     PostImageManager.instance.expects(:uploaders).returns([ preview_uploader ])
+    PostImageManager.instance.expects(:downloaded_images).returns([ post_image ]).never
 
     markdown = '![My Alt Text](/assets/img/20170610130401_1.jpg)'
     expected_html = "<p><img src=\"/uploads/tmp/my cache/preview_20170610130401_1.jpg\" alt=\"My Alt Text\" /></p>\n"
+
+    # Act
+    result = KramdownService.get_preview(markdown)
+
+    # Assert
+    assert_equal expected_html, result
+  end
+
+  test 'get_preview should update the src attribute of image tags if a PostImage exists in PostImageManager' do 
+    # Arrange
+    post_image = create_post_image('assets/img/20170610130401_1.jpg', 'contents')
+    markdown = '![My Alt Text](/assets/img/20170610130401_1.jpg)'
+    expected_html = "<p><img src=\"data:image/jpg;base64,contents\" alt=\"My Alt Text\" /></p>\n"
+
+    PostImageManager.instance.expects(:uploaders).returns([])
+    PostImageManager.instance.expects(:downloaded_images).returns([ post_image ])
 
     # Act
     result = KramdownService.get_preview(markdown)

--- a/test/services/kramdown_service_test.rb
+++ b/test/services/kramdown_service_test.rb
@@ -139,6 +139,17 @@ Andy is nice)
     assert_equal 'assets/img/My File2.jpg', result[1]
   end
 
+  test 'get_all_images_paths should not return image paths from URIs' do 
+    # Arrange
+    markdown = '![My Alt Text](https://google.com/blah.jpg)'
+
+    # Act
+    result = KramdownService.get_all_image_paths(markdown)
+
+    # Assert
+    assert_equal 0, result.length
+  end
+
   test 'create_jekyll_post_text should return text for a formatted post' do 
     # Arrange
     expected_post = %(---

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,6 +3,7 @@ SimpleCov.start 'rails'
 ENV['RAILS_ENV'] ||= 'test'
 require_relative '../config/environment'
 require 'rails/test_help'
+require_relative '../app/models/post'
 
 class ActiveSupport::TestCase
   ENV['GH_BASIC_CLIENT_ID'] = 'github client id'
@@ -80,6 +81,13 @@ class ActiveSupport::TestCase
     def create_mock_action_dispatch_file(filename)
       result = MockActionDispatchFile.new
       result.original_filename = filename
+      result
+    end
+
+    def create_post_image(filename, contents)
+      result = PostImage.new
+      result.filename = filename
+      result.contents = contents
       result
     end
 end


### PR DESCRIPTION
This is a new type of edit added to the editor where we are now able to edit posts that are in PR. Where the edit then is treated as a PR update. In the process of implementing this I fixed a lot of issues related to editing posts.

Issues Fixed:
- Added support for downloading existing images on the post when editing. I had problems getting CarrierWave to work with this so in the preview the src of the image is the base64 contents of the downloaded image.
- Fixed an issue where an edited post was showing the default hero in the UI if the post contained the default hero
- Made the logo in the header a link back to the list view.
- Changed the submission redirect to the list view when the post is valid. I thought this looked weird when submitting edits you were redirected to the blank edit screen like you were creating a post.